### PR TITLE
#26: Prohibit usage of "assertTrue" and "assertFalse" in tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* *1.6.0* (2025-05-09)
+    * Added rule DBR003 to prohibit usage of "assertTrue" and "assertFalse" in Django unittests
+
 * *1.5.3* (2025-05-09)
     * Fixed bug that DBR rules couldn't be ignored via "noqa" statements
 

--- a/boa_restrictor/__init__.py
+++ b/boa_restrictor/__init__.py
@@ -1,3 +1,3 @@
 """A custom Python linter from Ambient"""
 
-__version__ = "1.5.3"
+__version__ = "1.6.0"

--- a/boa_restrictor/rules/__init__.py
+++ b/boa_restrictor/rules/__init__.py
@@ -1,3 +1,4 @@
+from boa_restrictor.rules.django.no_assert_booleans_in_tests import ProhibitAssertBooleanInTests
 from boa_restrictor.rules.django.no_db_in_views import NoDjangoDbImportInViewsRule
 from boa_restrictor.rules.django.prohibit_assert_raises import AssertRaisesProhibitedRule
 from boa_restrictor.rules.python.abstract_class_inherits_from_abc import AbstractClassesInheritFromAbcRule
@@ -19,6 +20,7 @@ BOA_RESTRICTOR_RULES = (
 DJANGO_BOA_RULES = (
     AssertRaisesProhibitedRule,
     NoDjangoDbImportInViewsRule,
+    ProhibitAssertBooleanInTests,
 )
 
 

--- a/boa_restrictor/rules/django/no_assert_booleans_in_tests.py
+++ b/boa_restrictor/rules/django/no_assert_booleans_in_tests.py
@@ -1,0 +1,52 @@
+import ast
+
+from boa_restrictor.common.rule import DJANGO_LINTING_RULE_PREFIX, Rule
+from boa_restrictor.projections.occurrence import Occurrence
+
+
+class ProhibitAssertBooleanInTests(Rule):
+    """
+    Prohibit the usage of "assertTrue" and "assertFalse" in Django unittests.
+    """
+
+    RULE_ID = f"{DJANGO_LINTING_RULE_PREFIX}003"
+    RULE_LABEL = (
+        'Do not use "assertTrue" or "assertFalse" in Django unittests. Use "assertIs(x, True)" or '
+        '"assertIs(x, False)" instead.'
+    )
+
+    def is_testcase_class(self, class_node):
+        for base in class_node.bases:
+            if isinstance(base, ast.Attribute):
+                if base.attr == "TestCase":
+                    return True
+            elif isinstance(base, ast.Name):
+                if base.id == "TestCase":  # pragma: no cover (this line gets hit in every branch)
+                    return True
+        return False
+
+    def check(self) -> list[Occurrence]:
+        occurrences = []
+        for node in ast.walk(self.source_tree):
+            if not (isinstance(node, ast.ClassDef) and self.is_testcase_class(node)):
+                continue
+            for class_item in node.body:
+                if not isinstance(class_item, ast.FunctionDef):
+                    continue
+                for subnode in ast.walk(class_item):
+                    if not isinstance(subnode, ast.Call):
+                        continue
+                    func = subnode.func
+                    if isinstance(func, ast.Attribute) and func.attr in {"assertTrue", "assertFalse"}:
+                        occurrences.append(
+                            Occurrence(
+                                filename=self.filename,
+                                file_path=self.file_path,
+                                rule_label=self.RULE_LABEL,
+                                rule_id=self.RULE_ID,
+                                line_number=node.lineno,
+                                identifier=None,
+                            )
+                        )
+
+        return occurrences

--- a/docs/features/rules.md
+++ b/docs/features/rules.md
@@ -178,3 +178,38 @@ if typing.TYPE_CHECKING:
 class MyView(generic.DetailView):
     def get_queryset(self) -> QuerySet: ...
 ```
+
+### Prohibit usage of "assertTrue" and "assertFalse" in Django unittests (DBR003)
+
+Using "assertTrue" or "assertFalse" in unittests might lead to false positives in your test results since these methods
+will cast the given value to boolean.
+
+This means that x = 1 will make `assertTrue(x)` pass but `assertIs(x, True)` will fail.
+
+Since explicit is better than implicit, the usage of these methods is discouraged.
+
+*Wrong:*
+
+```python
+from django.test import TestCase
+
+
+class MyTest(TestCase):
+    def test_x(self):
+        ...
+        self.assertTrue(x)
+        self.assertFalse(y)
+```
+
+*Correct:*
+
+```python
+from django.test import TestCase
+
+
+class MyTest(TestCase):
+    def test_x(self):
+        ...
+        self.assertIs(x, True)
+        self.assertIs(y, False)
+```

--- a/tests/rules/django/test_no_assert_booleans_in_tests.py
+++ b/tests/rules/django/test_no_assert_booleans_in_tests.py
@@ -1,0 +1,98 @@
+import ast
+from pathlib import Path
+
+from boa_restrictor.projections.occurrence import Occurrence
+from boa_restrictor.rules.django.no_assert_booleans_in_tests import ProhibitAssertBooleanInTests
+
+
+def test_check_assert_true_found():
+    source_tree = ast.parse("""class MyTest(TestCase):
+    def test_x(self):
+        self.assertTrue(x)""")
+
+    occurrences = ProhibitAssertBooleanInTests.run_check(file_path=Path("test_x.py"), source_tree=source_tree)
+
+    assert len(occurrences) == 1
+    assert occurrences[0] == Occurrence(
+        filename="test_x.py",
+        file_path=Path("test_x.py"),
+        line_number=1,
+        rule_id=ProhibitAssertBooleanInTests.RULE_ID,
+        rule_label=ProhibitAssertBooleanInTests.RULE_LABEL,
+        identifier=None,
+    )
+
+
+def test_check_assert_false_found():
+    source_tree = ast.parse("""class MyTest(TestCase):
+    def test_x(self):
+        self.assertFalse(x)""")
+
+    occurrences = ProhibitAssertBooleanInTests.run_check(file_path=Path("test_x.py"), source_tree=source_tree)
+
+    assert len(occurrences) == 1
+    assert occurrences[0] == Occurrence(
+        filename="test_x.py",
+        file_path=Path("test_x.py"),
+        line_number=1,
+        rule_id=ProhibitAssertBooleanInTests.RULE_ID,
+        rule_label=ProhibitAssertBooleanInTests.RULE_LABEL,
+        identifier=None,
+    )
+
+
+def test_check_assert_via_test_case_class_indirect_usage():
+    source_tree = ast.parse("""class MyTest(tests.TestCase):
+    def test_x(self):
+        self.assertFalse(x)""")
+
+    occurrences = ProhibitAssertBooleanInTests.run_check(file_path=Path("test_x.py"), source_tree=source_tree)
+
+    assert len(occurrences) == 1
+    assert occurrences[0] == Occurrence(
+        filename="test_x.py",
+        file_path=Path("test_x.py"),
+        line_number=1,
+        rule_id=ProhibitAssertBooleanInTests.RULE_ID,
+        rule_label=ProhibitAssertBooleanInTests.RULE_LABEL,
+        identifier=None,
+    )
+
+
+def test_check_different_assert_not_found():
+    source_tree = ast.parse("""class MyTest(TestCase):
+    def test_x(self):
+        self.assertIs(x, True)""")
+
+    occurrences = ProhibitAssertBooleanInTests.run_check(file_path=Path("test_x.py"), source_tree=source_tree)
+
+    assert len(occurrences) == 0
+
+
+def test_check_assert_in_different_class():
+    source_tree = ast.parse("""class MyTest(Service):
+    def test_x(self):
+        self.assertTrue(x)""")
+
+    occurrences = ProhibitAssertBooleanInTests.run_check(file_path=Path("test_x.py"), source_tree=source_tree)
+
+    assert len(occurrences) == 0
+
+
+def test_check_assert_in_different_class_indirect_import():
+    source_tree = ast.parse("""class MyTest(my_app.Service):
+    def test_x(self):
+        self.assertTrue(x)""")
+
+    occurrences = ProhibitAssertBooleanInTests.run_check(file_path=Path("test_x.py"), source_tree=source_tree)
+
+    assert len(occurrences) == 0
+
+
+def test_check_assert_with_class_variable():
+    source_tree = ast.parse("""class MyTest(TestCase):
+    something = 123""")
+
+    occurrences = ProhibitAssertBooleanInTests.run_check(file_path=Path("test_x.py"), source_tree=source_tree)
+
+    assert len(occurrences) == 0


### PR DESCRIPTION
Fixed #26.