### PR TITLE
Fix: Exclude test files from DB import checks in view and API layers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**Unreleased**
+  * Fixed: Exclude test files (starting with `test_`) from `DBR002` and `DBR005` checks to prevent false positives when test files are located within `views/` or `api/` directories
+
 **1.13.3** (2026-03-30)
 * Maintenance via ambient-package-update
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-**Unreleased**
+**1.13.4** (2026-04-30)
   * Fixed: Exclude test files (starting with `test_`) from `DBR002` and `DBR005` checks to prevent false positives when test files are located within `views/` or `api/` directories
 
 **1.13.3** (2026-03-30)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
   * Fixed: Exclude test files (starting with `test_`) from `DBR002` and `DBR005` checks to prevent false positives when test files are located within `views/` or `api/` directories
 
 **1.13.3** (2026-03-30)
-* Maintenance via ambient-package-update
+  * Maintenance via ambient-package-update
 
 **1.13.2** (2026-03-30)
   * Maintenance updates via ambient-package-update
@@ -87,83 +87,83 @@
 **1.7.3** (2025-05-29)
   * Maintenance updates via ambient-package-update
 
-* *1.7.2* (2025-05-12)
-    * Fixed a bug in the docs at "DBR002"
+**1.7.2** (2025-05-12)
+  * Fixed a bug in the docs at "DBR002"
 
-* *1.7.1* (2025-05-12)
-    * Updated docs about ruff support and Django-based rules
+**1.7.1** (2025-05-12)
+  * Updated docs about ruff support and Django-based rules
 
-* *1.7.0* (2025-05-09)
-    * Avoid usage of type-hints in variable names as suffixes (PBR007)
+**1.7.0** (2025-05-09)
+  * Avoid usage of type-hints in variable names as suffixes (PBR007)
 
-* *1.6.0* (2025-05-09)
-    * Added rule DBR003 to prohibit usage of "assertTrue" and "assertFalse" in Django unittests
+**1.6.0** (2025-05-09)
+  * Added rule DBR003 to prohibit usage of "assertTrue" and "assertFalse" in Django unittests
 
-* *1.5.3* (2025-05-09)
-    * Fixed bug that DBR rules couldn't be ignored via "noqa" statements
+**1.5.3** (2025-05-09)
+  * Fixed bug that DBR rules couldn't be ignored via "noqa" statements
 
-* *1.5.2* (2025-05-09)
-    * Removed matches of DBR002 if import is just for type-hinting purposes
+**1.5.2** (2025-05-09)
+  * Removed matches of DBR002 if import is just for type-hinting purposes
 
-* *1.5.1* (2025-04-16)
-    * Fixed a bug which would show wrong occurrence paths in pre-commit output
+**1.5.1** (2025-04-16)
+  * Fixed a bug which would show wrong occurrence paths in pre-commit output
 
-* *1.5.0* (2025-04-16)
-    * Added Django-only rule to prohibit usage of "django.db" in the view layer
+**1.5.0** (2025-04-16)
+  * Added Django-only rule to prohibit usage of "django.db" in the view layer
 
-* *1.4.0* (2025-04-11)
-    * Added first Django-only rule to prohibit use of `TestCase.assertRaises()`
+**1.4.0** (2025-04-11)
+  * Added first Django-only rule to prohibit use of `TestCase.assertRaises()`
 
-* *1.3.5* (2025-04-04)
-    * Caught exception when pyproject.toml contains syntax errors
+**1.3.5** (2025-04-04)
+  * Caught exception when pyproject.toml contains syntax errors
 
-* *1.3.4* (2025-04-04)
-    * Maintenance via ambient-package-update
+**1.3.4** (2025-04-04)
+  * Maintenance via ambient-package-update
 
-* *1.3.3* (2025-01-15)
-    * Fixed a crash when invalid source code was passed to the linter
+**1.3.3** (2025-01-15)
+  * Fixed a crash when invalid source code was passed to the linter
 
-* *1.3.2* (2025-01-15)
-    * Moved parts of documentation from Readme to RTD
+**1.3.2** (2025-01-15)
+  * Moved parts of documentation from Readme to RTD
 
-* *1.3.1* (2025-01-13)
-    * Added check in unittests to avoid forgetting to register new rules
+**1.3.1** (2025-01-13)
+  * Added check in unittests to avoid forgetting to register new rules
 
-* *1.3.0* (2025-01-13)
-    * Added rule `PBR005` for ensuring service classes have exactly one public method called "process"
-    * Added rule `PBR006` for ensuring abstract classes inherit from `abc.ABC`
+**1.3.0** (2025-01-13)
+  * Added rule `PBR005` for ensuring service classes have exactly one public method called "process"
+  * Added rule `PBR006` for ensuring abstract classes inherit from `abc.ABC`
 
-* *1.2.1* (2024-12-13)
-    * Allowed other imports from `datetime` module except `datetime` and `date`
+**1.2.1** (2024-12-13)
+  * Allowed other imports from `datetime` module except `datetime` and `date`
 
-* *1.2.0* (2024-12-10)
-    * Added per-file exclusion list in configuration
-    * Added warnings if non-existing rules are excluded in the configuration
-    * Removed occurrence counter output in CLI since `pre-commit` calls the linter recursively
+**1.2.0** (2024-12-10)
+  * Added per-file exclusion list in configuration
+  * Added warnings if non-existing rules are excluded in the configuration
+  * Removed occurrence counter output in CLI since `pre-commit` calls the linter recursively
 
-* *1.1.2* (2024-12-09)
-    * Removed success message since `pre-commit` runs any linter *x* times
+**1.1.2** (2024-12-09)
+  * Removed success message since `pre-commit` runs any linter *x* times
 
-* *1.1.1* (2024-12-09)
-    * Fixed a bug that caused `PBR004` not to be executed
+**1.1.1** (2024-12-09)
+  * Fixed a bug that caused `PBR004` not to be executed
 
-* *1.1.0* (2024-12-09)
-    * Added rule `PBR003` for prohibiting import nested datetime from datetime module
-    * Added rule `PBR004` for enforcing `kw_only` parameter for dataclasses
-    * Moved AST creation from rule declaration to cli level for performance reasons
+**1.1.0** (2024-12-09)
+  * Added rule `PBR003` for prohibiting import nested datetime from datetime module
+  * Added rule `PBR004` for enforcing `kw_only` parameter for dataclasses
+  * Moved AST creation from rule declaration to cli level for performance reasons
 
-* *1.0.3* (2024-12-02)
-    * Re-added Django dependency
-    * Added ruff linting rules
+**1.0.3** (2024-12-02)
+  * Re-added Django dependency
+  * Added ruff linting rules
 
-* *1.0.2* (2024-12-02)
-    * Fixed sphinx docs
+**1.0.2** (2024-12-02)
+  * Fixed sphinx docs
 
-* *1.0.1* (2024-12-02)
-    * Added forgotten changelog
-    * Added docs for git tags for pre-commit
+**1.0.1** (2024-12-02)
+  * Added forgotten changelog
+  * Added docs for git tags for pre-commit
 
-* *1.0.0* (2024-12-02)
-    * Added rule `PBR001` for enforcing kwargs in functions and methods
-    * Added rule `PBR002` for enforcing return type-hints when a function contains a return statement
-    * Project setup and configuration
+**1.0.0** (2024-12-02)
+  * Added rule `PBR001` for enforcing kwargs in functions and methods
+  * Added rule `PBR002` for enforcing return type-hints when a function contains a return statement
+  * Project setup and configuration

--- a/boa_restrictor/rules/django/no_db_in_api.py
+++ b/boa_restrictor/rules/django/no_db_in_api.py
@@ -16,6 +16,9 @@ class NoDjangoDbImportInApiRule(Rule):
     def is_api_file(self, path: Path) -> bool:
         path = path.resolve()
 
+        if path.name.startswith("test_"):
+            return False
+
         if path.name == "api.py":
             return True
 

--- a/boa_restrictor/rules/django/no_db_in_views.py
+++ b/boa_restrictor/rules/django/no_db_in_views.py
@@ -16,6 +16,9 @@ class NoDjangoDbImportInViewsRule(Rule):
     def is_view_file(self, path: Path) -> bool:
         path = path.resolve()
 
+        if path.name.startswith("test_"):
+            return False
+
         if path.name == "views.py":
             return True
 

--- a/docs/features/rules/django/002_avoid_django_db_imports_in_views.md
+++ b/docs/features/rules/django/002_avoid_django_db_imports_in_views.md
@@ -7,6 +7,10 @@ complex integration test.
 
 Note that imports for type-hinting purposes are fine.
 
+## Test Files
+
+Test files (files starting with `test_`) are automatically excluded from this rule, even if they are located within the `views/` directory structure. This allows test files to import from `django.db` as needed for testing purposes.
+
 *Wrong:*
 
 ```python

--- a/docs/features/rules/django/005_avoid_django_db_imports_in_api.md
+++ b/docs/features/rules/django/005_avoid_django_db_imports_in_api.md
@@ -7,6 +7,10 @@ a way more complex integration test.
 
 Note that imports for type-hinting purposes are fine.
 
+## Test Files
+
+Test files (files starting with `test_`) are automatically excluded from this rule, even if they are located within the `api/` directory structure. This allows test files to import from `django.db` as needed for testing purposes.
+
 *Wrong:*
 
 ```python

--- a/tests/rules/django/test_no_db_in_api.py
+++ b/tests/rules/django/test_no_db_in_api.py
@@ -170,3 +170,53 @@ def test_check_test_file_in_api_dir_is_ok():
     )
 
     assert len(occurrences) == 0
+
+
+def test_check_test_file_with_from_import_in_api_dir():
+    source_tree = ast.parse("""from django.db import models""")
+
+    occurrences = NoDjangoDbImportInApiRule.run_check(
+        file_path=Path("/path/to/api/test_models.py"), source_tree=source_tree
+    )
+
+    assert len(occurrences) == 0
+
+
+def test_check_test_file_with_db_import_in_api_dir():
+    source_tree = ast.parse("""from django import db""")
+
+    occurrences = NoDjangoDbImportInApiRule.run_check(
+        file_path=Path("/path/to/api/test_database.py"), source_tree=source_tree
+    )
+
+    assert len(occurrences) == 0
+
+
+def test_check_exact_test_api_filename_in_api_dir():
+    source_tree = ast.parse("""import django.db.models""")
+
+    occurrences = NoDjangoDbImportInApiRule.run_check(
+        file_path=Path("/app/api/test_api.py"), source_tree=source_tree
+    )
+
+    assert len(occurrences) == 0
+
+
+def test_check_test_file_in_tests_api_subdir():
+    source_tree = ast.parse("""import django.db.models""")
+
+    occurrences = NoDjangoDbImportInApiRule.run_check(
+        file_path=Path("/app/tests/api/test_serializers.py"), source_tree=source_tree
+    )
+
+    assert len(occurrences) == 0
+
+
+def test_check_non_test_file_in_tests_api_subdir_still_fails():
+    source_tree = ast.parse("""import django.db.models""")
+
+    occurrences = NoDjangoDbImportInApiRule.run_check(
+        file_path=Path("/app/tests/api/serializers.py"), source_tree=source_tree
+    )
+
+    assert len(occurrences) == 1

--- a/tests/rules/django/test_no_db_in_api.py
+++ b/tests/rules/django/test_no_db_in_api.py
@@ -195,9 +195,7 @@ def test_check_test_file_with_db_import_in_api_dir():
 def test_check_exact_test_api_filename_in_api_dir():
     source_tree = ast.parse("""import django.db.models""")
 
-    occurrences = NoDjangoDbImportInApiRule.run_check(
-        file_path=Path("/app/api/test_api.py"), source_tree=source_tree
-    )
+    occurrences = NoDjangoDbImportInApiRule.run_check(file_path=Path("/app/api/test_api.py"), source_tree=source_tree)
 
     assert len(occurrences) == 0
 

--- a/tests/rules/django/test_no_db_in_api.py
+++ b/tests/rules/django/test_no_db_in_api.py
@@ -160,3 +160,13 @@ def test_check_other_ifs_are_ignored():
         rule_label=NoDjangoDbImportInApiRule.RULE_LABEL,
         identifier=None,
     )
+
+
+def test_check_test_file_in_api_dir_is_ok():
+    source_tree = ast.parse("""import django.db.models""")
+
+    occurrences = NoDjangoDbImportInApiRule.run_check(
+        file_path=Path("/path/to/api/test_user_api.py"), source_tree=source_tree
+    )
+
+    assert len(occurrences) == 0

--- a/tests/rules/django/test_no_db_in_views.py
+++ b/tests/rules/django/test_no_db_in_views.py
@@ -190,3 +190,13 @@ def test_check_other_ifs_are_ignored():
         rule_label=NoDjangoDbImportInViewsRule.RULE_LABEL,
         identifier=None,
     )
+
+
+def test_check_test_file_in_views_dir_is_ok():
+    source_tree = ast.parse("""import django.db.models""")
+
+    occurrences = NoDjangoDbImportInViewsRule.run_check(
+        file_path=Path("/path/to/views/test_user_views.py"), source_tree=source_tree
+    )
+
+    assert len(occurrences) == 0

--- a/tests/rules/django/test_no_db_in_views.py
+++ b/tests/rules/django/test_no_db_in_views.py
@@ -200,3 +200,53 @@ def test_check_test_file_in_views_dir_is_ok():
     )
 
     assert len(occurrences) == 0
+
+
+def test_check_test_file_with_from_import_in_views_dir():
+    source_tree = ast.parse("""from django.db import models""")
+
+    occurrences = NoDjangoDbImportInViewsRule.run_check(
+        file_path=Path("/path/to/views/test_models.py"), source_tree=source_tree
+    )
+
+    assert len(occurrences) == 0
+
+
+def test_check_test_file_with_db_import_in_views_dir():
+    source_tree = ast.parse("""from django import db""")
+
+    occurrences = NoDjangoDbImportInViewsRule.run_check(
+        file_path=Path("/path/to/views/test_database.py"), source_tree=source_tree
+    )
+
+    assert len(occurrences) == 0
+
+
+def test_check_exact_test_views_filename_in_views_dir():
+    source_tree = ast.parse("""import django.db.models""")
+
+    occurrences = NoDjangoDbImportInViewsRule.run_check(
+        file_path=Path("/app/views/test_views.py"), source_tree=source_tree
+    )
+
+    assert len(occurrences) == 0
+
+
+def test_check_test_file_in_tests_views_subdir():
+    source_tree = ast.parse("""import django.db.models""")
+
+    occurrences = NoDjangoDbImportInViewsRule.run_check(
+        file_path=Path("/app/tests/views/test_serializers.py"), source_tree=source_tree
+    )
+
+    assert len(occurrences) == 0
+
+
+def test_check_non_test_file_in_tests_views_subdir_still_fails():
+    source_tree = ast.parse("""import django.db.models""")
+
+    occurrences = NoDjangoDbImportInViewsRule.run_check(
+        file_path=Path("/app/tests/views/serializers.py"), source_tree=source_tree
+    )
+
+    assert len(occurrences) == 1


### PR DESCRIPTION
Hey @GitRon,

I had the problem, that I imported from db in my tests (I needed to mock a DB-level NOW()) but the prek hook failed, because "views are not allowed to import from db".

I think, that files, testings views should be allowed to do so.

=> Test files (starting with 'test_') are now excluded from both NoDjangoDbImportInViewsRule (DBR002) and NoDjangoDbImportInApiRule (DBR005). This prevents false positives when test files are located within views/ or api/ directories and legitimately import from django.db.

- Add test file detection in is_view_file() and is_api_file()
- Add test cases to verify the fix