### PR TITLE
Add support for project-specific custom rules (v1.14.0)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,20 @@
 # Changelog
 
-**1.14.0** (2026-05-04)
+**1.14.0** (2026-05-05)
 * Added support for project-specific (custom) rules via the `custom_rules` setting in `pyproject.toml`
 * Generalised `# noqa: <CODE>` detection to recognise custom rule IDs (no longer limited to `PBR`/`DBR` prefixes)
-* Fixed a bug where `# noqa` codes were matched as substrings (`# noqa: PBR0011` could mute `PBR001`); codes are now matched exactly
+* Fixed a bug where `# noqa` codes were matched as substrings (`# noqa: PBR0011` could mute `PBR001`); codes are now
+  matched exactly
+* Fixed a bug where code-shaped tokens *outside* the `# noqa:` payload (e.g. `# fixes PBR001 ticket  # noqa: PBR002`)
+  silently widened the suppression set; only codes after `# noqa:` and before any subsequent `#` are now honoured
+* Accept uppercase (`# NOQA:`) and whitespace-tolerant (`#noqa:PBR001`) noqa directives, matching flake8/ruff
+* Fixed a bug in the `exclude` list where a single invalid rule ID silently disabled all other exclusions for that rule;
+  invalid IDs now warn but valid ones are still honoured
+* Malformed source files (e.g. unterminated triple-quoted strings) now produce the user-friendly
+  `BoaRestrictorParsingError` instead of a raw `tokenize.TokenError`
+* Custom rules are validated eagerly at load time: `RULE_ID` must match `^[A-Z]+\d+$` (e.g. `MYP001`), and both
+  `RULE_ID` and `RULE_LABEL` must be strings — misconfigured rules fail the run with a clear message before any file is
+  linted
 
 **1.13.3** (2026-03-30)
 * Maintenance via ambient-package-update

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 **1.14.0** (2026-05-04)
 * Added support for project-specific (custom) rules via the `custom_rules` setting in `pyproject.toml`
 * Generalised `# noqa: <CODE>` detection to recognise custom rule IDs (no longer limited to `PBR`/`DBR` prefixes)
+* Fixed a bug where `# noqa` codes were matched as substrings (`# noqa: PBR0011` could mute `PBR001`); codes are now matched exactly
 
 **1.13.3** (2026-03-30)
 * Maintenance via ambient-package-update

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**1.14.0** (2026-05-04)
+* Added support for project-specific (custom) rules via the `custom_rules` setting in `pyproject.toml`
+* Generalised `# noqa: <CODE>` detection to recognise custom rule IDs (no longer limited to `PBR`/`DBR` prefixes)
+
 **1.13.3** (2026-03-30)
 * Maintenance via ambient-package-update
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add the following to your .pre-commit-config.yaml file:
 
 ```yaml
   - repo: https://github.com/ambient-innovation/boa-restrictor
-    rev: v1.13.3
+    rev: v1.14.0
     hooks:
       - id: boa-restrictor
         args: [ --config=pyproject.toml ]

--- a/boa_restrictor/__init__.py
+++ b/boa_restrictor/__init__.py
@@ -1,3 +1,3 @@
 """A custom Python and Django linter from Ambient"""
 
-__version__ = "1.13.3"
+__version__ = "1.14.0"

--- a/boa_restrictor/cli/configuration.py
+++ b/boa_restrictor/cli/configuration.py
@@ -43,14 +43,14 @@ def is_rule_excluded(*, rule_class: type[Rule], excluded_rules: list, active_rul
     if active_rule_ids is None:
         active_rule_ids = {rule_class.RULE_ID for rule_class in get_rules(use_django_rules=True)}
 
-    # Check if the given rule is valid
+    # Warn for any invalid IDs in the exclusion list, but still honour the valid ones.
+    # An early return here would mean a single typo silently disabled all exclusions.
     for invalid_configured_rule in [rule_id for rule_id in excluded_rules if rule_id not in active_rule_ids]:
         warnings.warn(
             f'Boa Restrictor: Invalid rule "{invalid_configured_rule}" in configuration detected.',
             category=UserWarning,
             stacklevel=2,
         )
-        return False
 
     # Check if the given rule is in the exclusion list
     return rule_class.RULE_ID in excluded_rules

--- a/boa_restrictor/cli/configuration.py
+++ b/boa_restrictor/cli/configuration.py
@@ -33,15 +33,18 @@ def load_configuration(*, file_path: Path | str = "pyproject.toml") -> dict:
         return {}
 
 
-def is_rule_excluded(*, rule_class: type[Rule], excluded_rules: list) -> bool:
+def is_rule_excluded(*, rule_class: type[Rule], excluded_rules: list, active_rule_ids: set[str] | None = None) -> bool:
     """
     Check if the given rule is in the exclusion list.
+
+    `active_rule_ids` is the set of all known rule IDs (built-in + any project-level custom rules).
+    If omitted, only built-in rules are considered valid.
     """
-    # Generate list of valid rules (filtering Django rules happens one level above)
-    valid_rules = [rule_class.RULE_ID for rule_class in get_rules(use_django_rules=True)]
+    if active_rule_ids is None:
+        active_rule_ids = {rule_class.RULE_ID for rule_class in get_rules(use_django_rules=True)}
 
     # Check if the given rule is valid
-    for invalid_configured_rule in [rule_id for rule_id in excluded_rules if rule_id not in valid_rules]:
+    for invalid_configured_rule in [rule_id for rule_id in excluded_rules if rule_id not in active_rule_ids]:
         warnings.warn(
             f'Boa Restrictor: Invalid rule "{invalid_configured_rule}" in configuration detected.',
             category=UserWarning,
@@ -54,7 +57,11 @@ def is_rule_excluded(*, rule_class: type[Rule], excluded_rules: list) -> bool:
 
 
 def is_rule_excluded_per_file(
-    *, filename: str, rule_class: type[Rule], per_file_excluded_rules: dict[str, list]
+    *,
+    filename: str,
+    rule_class: type[Rule],
+    per_file_excluded_rules: dict[str, list],
+    active_rule_ids: set[str] | None = None,
 ) -> bool:
     """
     Check if the given rule is in the per-file-exclusion list.
@@ -64,6 +71,10 @@ def is_rule_excluded_per_file(
         # If the filename matches the pattern...
         if re.search(fnmatch.translate(file_path_pattern), filename):
             # Skip linters, which have been excluded for this file path pattern
-            if is_rule_excluded(rule_class=rule_class, excluded_rules=per_file_excluded_rules[file_path_pattern]):
+            if is_rule_excluded(
+                rule_class=rule_class,
+                excluded_rules=per_file_excluded_rules[file_path_pattern],
+                active_rule_ids=active_rule_ids,
+            ):
                 return True
     return False

--- a/boa_restrictor/cli/custom_rules.py
+++ b/boa_restrictor/cli/custom_rules.py
@@ -91,16 +91,13 @@ def _import_custom_rule(*, dotted_path: str) -> type[Rule]:
 def validate_unique_rule_ids(*, rules: tuple[type[Rule], ...]) -> None:
     """
     Ensure no two rules share a RULE_ID, naming all offenders if any clash.
-    Collects every duplicate before raising so users see the full picture in one go.
+    Collects every duplicate before raising so users see the full picture in one go,
+    grouped by rule ID (a triple-clash reports as one line with three classes).
     """
-    seen: dict[str, type[Rule]] = {}
-    clashes: list[tuple[str, type[Rule], type[Rule]]] = []
+    by_id: dict[str, list[type[Rule]]] = {}
     for rule in rules:
-        existing = seen.get(rule.RULE_ID)
-        if existing is not None:
-            clashes.append((rule.RULE_ID, existing, rule))
-        else:
-            seen[rule.RULE_ID] = rule
+        by_id.setdefault(rule.RULE_ID, []).append(rule)
 
+    clashes = {rule_id: classes for rule_id, classes in by_id.items() if len(classes) > 1}
     if clashes:
         raise DuplicateRuleIdError(clashes=clashes)

--- a/boa_restrictor/cli/custom_rules.py
+++ b/boa_restrictor/cli/custom_rules.py
@@ -1,10 +1,12 @@
 import importlib
+import re
 import sys
 from pathlib import Path
 
 from boa_restrictor.common.rule import RESERVED_RULE_ID_PREFIXES, Rule
 from boa_restrictor.exceptions.custom_rules import (
     CustomRuleAttributeMissingError,
+    CustomRuleInvalidRuleIdShapeError,
     CustomRuleInvalidRuleIdTypeError,
     CustomRuleInvalidRuleLabelTypeError,
     CustomRuleMissingRuleIdError,
@@ -20,13 +22,22 @@ from boa_restrictor.exceptions.custom_rules import (
     InvalidCustomRulePathError,
 )
 
+# Mirrors the noqa parser's _CODE_PATTERN: a RULE_ID that doesn't match this shape
+# can never be silenced via "# noqa:", so reject it at load time.
+_RULE_ID_SHAPE = re.compile(r"^[A-Z]+\d+$")
+
 
 def load_custom_rules(*, paths, anchor_dir: Path) -> tuple[type[Rule], ...]:
     """
     Import custom rule classes from a list of dotted paths (e.g. "myproject.linting.MyRule").
 
-    `anchor_dir` is prepended to sys.path so the user's project modules become importable
-    when boa-restrictor runs as an installed console script.
+    `anchor_dir` is prepended to sys.path (insert at position 0) so the user's project modules
+    become importable when boa-restrictor runs as an installed console script. Inserting at the
+    front means project-local modules win over identically-named installed packages — that's
+    the intended behaviour, since the user is linting their own project.
+
+    The anchor is canonicalised with `Path.resolve()` so non-canonical inputs (e.g. paths
+    containing "..") don't accumulate as duplicate sys.path entries on repeated invocations.
     """
     if not isinstance(paths, list):
         raise CustomRulesNotAListError
@@ -37,7 +48,7 @@ def load_custom_rules(*, paths, anchor_dir: Path) -> tuple[type[Rule], ...]:
     if not paths:
         return ()
 
-    anchor_str = str(anchor_dir)
+    anchor_str = str(anchor_dir.resolve())
     if anchor_str not in sys.path:
         sys.path.insert(0, anchor_str)
 
@@ -87,6 +98,8 @@ def _validate_rule_class(*, rule_attr, dotted_path: str) -> None:
         raise CustomRuleMissingRuleLabelError(dotted_path)
     if not isinstance(rule_attr.RULE_LABEL, str):
         raise CustomRuleInvalidRuleLabelTypeError(dotted_path=dotted_path, value=rule_attr.RULE_LABEL)
+    if not _RULE_ID_SHAPE.match(rule_attr.RULE_ID):
+        raise CustomRuleInvalidRuleIdShapeError(dotted_path=dotted_path, rule_id=rule_attr.RULE_ID)
 
     for prefix in RESERVED_RULE_ID_PREFIXES:
         if rule_attr.RULE_ID.startswith(prefix):

--- a/boa_restrictor/cli/custom_rules.py
+++ b/boa_restrictor/cli/custom_rules.py
@@ -2,7 +2,7 @@ import importlib
 import sys
 from pathlib import Path
 
-from boa_restrictor.common.rule import DJANGO_LINTING_RULE_PREFIX, PYTHON_LINTING_RULE_PREFIX, Rule
+from boa_restrictor.common.rule import RESERVED_RULE_ID_PREFIXES, Rule
 from boa_restrictor.exceptions.custom_rules import (
     CustomRuleAttributeMissingError,
     CustomRuleMissingRuleIdError,
@@ -10,14 +10,13 @@ from boa_restrictor.exceptions.custom_rules import (
     CustomRuleModuleImportFailedError,
     CustomRuleNotAClassError,
     CustomRuleNotARuleSubclassError,
+    CustomRulePathNotAStringError,
     CustomRuleReservedPrefixError,
     CustomRulesNotAListError,
     DuplicateCustomRulePathError,
     DuplicateRuleIdError,
     InvalidCustomRulePathError,
 )
-
-RESERVED_RULE_ID_PREFIXES = (PYTHON_LINTING_RULE_PREFIX, DJANGO_LINTING_RULE_PREFIX)
 
 
 def load_custom_rules(*, paths, anchor_dir: Path) -> tuple[type[Rule], ...]:
@@ -27,8 +26,11 @@ def load_custom_rules(*, paths, anchor_dir: Path) -> tuple[type[Rule], ...]:
     `anchor_dir` is prepended to sys.path so the user's project modules become importable
     when boa-restrictor runs as an installed console script.
     """
-    if not isinstance(paths, list) or not all(isinstance(item, str) for item in paths):
+    if not isinstance(paths, list):
         raise CustomRulesNotAListError
+    for item in paths:
+        if not isinstance(item, str):
+            raise CustomRulePathNotAStringError(item)
 
     if not paths:
         return ()
@@ -56,7 +58,7 @@ def _import_custom_rule(*, dotted_path: str) -> type[Rule]:
 
     try:
         module = importlib.import_module(module_path)
-    except ImportError as e:
+    except Exception as e:
         raise CustomRuleModuleImportFailedError(module_path=module_path, dotted_path=dotted_path, original=e) from e
 
     try:
@@ -88,11 +90,17 @@ def _import_custom_rule(*, dotted_path: str) -> type[Rule]:
 
 def validate_unique_rule_ids(*, rules: tuple[type[Rule], ...]) -> None:
     """
-    Ensure no two rules share a RULE_ID, naming both offenders if they do.
+    Ensure no two rules share a RULE_ID, naming all offenders if any clash.
+    Collects every duplicate before raising so users see the full picture in one go.
     """
     seen: dict[str, type[Rule]] = {}
+    clashes: list[tuple[str, type[Rule], type[Rule]]] = []
     for rule in rules:
         existing = seen.get(rule.RULE_ID)
         if existing is not None:
-            raise DuplicateRuleIdError(rule_id=rule.RULE_ID, first=existing, second=rule)
-        seen[rule.RULE_ID] = rule
+            clashes.append((rule.RULE_ID, existing, rule))
+        else:
+            seen[rule.RULE_ID] = rule
+
+    if clashes:
+        raise DuplicateRuleIdError(clashes=clashes)

--- a/boa_restrictor/cli/custom_rules.py
+++ b/boa_restrictor/cli/custom_rules.py
@@ -1,0 +1,98 @@
+import importlib
+import sys
+from pathlib import Path
+
+from boa_restrictor.common.rule import DJANGO_LINTING_RULE_PREFIX, PYTHON_LINTING_RULE_PREFIX, Rule
+from boa_restrictor.exceptions.custom_rules import (
+    CustomRuleAttributeMissingError,
+    CustomRuleMissingRuleIdError,
+    CustomRuleMissingRuleLabelError,
+    CustomRuleModuleImportFailedError,
+    CustomRuleNotAClassError,
+    CustomRuleNotARuleSubclassError,
+    CustomRuleReservedPrefixError,
+    CustomRulesNotAListError,
+    DuplicateCustomRulePathError,
+    DuplicateRuleIdError,
+    InvalidCustomRulePathError,
+)
+
+RESERVED_RULE_ID_PREFIXES = (PYTHON_LINTING_RULE_PREFIX, DJANGO_LINTING_RULE_PREFIX)
+
+
+def load_custom_rules(*, paths, anchor_dir: Path) -> tuple[type[Rule], ...]:
+    """
+    Import custom rule classes from a list of dotted paths (e.g. "myproject.linting.MyRule").
+
+    `anchor_dir` is prepended to sys.path so the user's project modules become importable
+    when boa-restrictor runs as an installed console script.
+    """
+    if not isinstance(paths, list) or not all(isinstance(item, str) for item in paths):
+        raise CustomRulesNotAListError
+
+    if not paths:
+        return ()
+
+    anchor_str = str(anchor_dir)
+    if anchor_str not in sys.path:
+        sys.path.insert(0, anchor_str)
+
+    seen_paths: set[str] = set()
+    rules: list[type[Rule]] = []
+    for dotted_path in paths:
+        if dotted_path in seen_paths:
+            raise DuplicateCustomRulePathError(dotted_path)
+        seen_paths.add(dotted_path)
+        rules.append(_import_custom_rule(dotted_path=dotted_path))
+
+    return tuple(rules)
+
+
+def _import_custom_rule(*, dotted_path: str) -> type[Rule]:
+    if "." not in dotted_path:
+        raise InvalidCustomRulePathError(dotted_path)
+
+    module_path, _, attr_name = dotted_path.rpartition(".")
+
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as e:
+        raise CustomRuleModuleImportFailedError(module_path=module_path, dotted_path=dotted_path, original=e) from e
+
+    try:
+        rule_attr = getattr(module, attr_name)
+    except AttributeError as e:
+        raise CustomRuleAttributeMissingError(
+            module_path=module_path, attr_name=attr_name, dotted_path=dotted_path
+        ) from e
+
+    if not isinstance(rule_attr, type):
+        raise CustomRuleNotAClassError(dotted_path)
+    if not issubclass(rule_attr, Rule):
+        raise CustomRuleNotARuleSubclassError(dotted_path)
+    if not getattr(rule_attr, "RULE_ID", None):
+        raise CustomRuleMissingRuleIdError(dotted_path)
+    if not getattr(rule_attr, "RULE_LABEL", None):
+        raise CustomRuleMissingRuleLabelError(dotted_path)
+
+    for prefix in RESERVED_RULE_ID_PREFIXES:
+        if rule_attr.RULE_ID.startswith(prefix):
+            raise CustomRuleReservedPrefixError(
+                dotted_path=dotted_path,
+                prefix=prefix,
+                reserved_prefixes=RESERVED_RULE_ID_PREFIXES,
+            )
+
+    return rule_attr
+
+
+def validate_unique_rule_ids(*, rules: tuple[type[Rule], ...]) -> None:
+    """
+    Ensure no two rules share a RULE_ID, naming both offenders if they do.
+    """
+    seen: dict[str, type[Rule]] = {}
+    for rule in rules:
+        existing = seen.get(rule.RULE_ID)
+        if existing is not None:
+            raise DuplicateRuleIdError(rule_id=rule.RULE_ID, first=existing, second=rule)
+        seen[rule.RULE_ID] = rule

--- a/boa_restrictor/cli/custom_rules.py
+++ b/boa_restrictor/cli/custom_rules.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from boa_restrictor.common.rule import RESERVED_RULE_ID_PREFIXES, Rule
 from boa_restrictor.exceptions.custom_rules import (
     CustomRuleAttributeMissingError,
+    CustomRuleInvalidRuleIdTypeError,
+    CustomRuleInvalidRuleLabelTypeError,
     CustomRuleMissingRuleIdError,
     CustomRuleMissingRuleLabelError,
     CustomRuleModuleImportFailedError,
@@ -68,14 +70,23 @@ def _import_custom_rule(*, dotted_path: str) -> type[Rule]:
             module_path=module_path, attr_name=attr_name, dotted_path=dotted_path
         ) from e
 
+    _validate_rule_class(rule_attr=rule_attr, dotted_path=dotted_path)
+    return rule_attr
+
+
+def _validate_rule_class(*, rule_attr, dotted_path: str) -> None:
     if not isinstance(rule_attr, type):
         raise CustomRuleNotAClassError(dotted_path)
     if not issubclass(rule_attr, Rule):
         raise CustomRuleNotARuleSubclassError(dotted_path)
     if not getattr(rule_attr, "RULE_ID", None):
         raise CustomRuleMissingRuleIdError(dotted_path)
+    if not isinstance(rule_attr.RULE_ID, str):
+        raise CustomRuleInvalidRuleIdTypeError(dotted_path=dotted_path, value=rule_attr.RULE_ID)
     if not getattr(rule_attr, "RULE_LABEL", None):
         raise CustomRuleMissingRuleLabelError(dotted_path)
+    if not isinstance(rule_attr.RULE_LABEL, str):
+        raise CustomRuleInvalidRuleLabelTypeError(dotted_path=dotted_path, value=rule_attr.RULE_LABEL)
 
     for prefix in RESERVED_RULE_ID_PREFIXES:
         if rule_attr.RULE_ID.startswith(prefix):
@@ -84,8 +95,6 @@ def _import_custom_rule(*, dotted_path: str) -> type[Rule]:
                 prefix=prefix,
                 reserved_prefixes=RESERVED_RULE_ID_PREFIXES,
             )
-
-    return rule_attr
 
 
 def validate_unique_rule_ids(*, rules: tuple[type[Rule], ...]) -> None:

--- a/boa_restrictor/cli/main.py
+++ b/boa_restrictor/cli/main.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from boa_restrictor.cli.configuration import is_rule_excluded, is_rule_excluded_per_file, load_configuration
+from boa_restrictor.cli.custom_rules import load_custom_rules, validate_unique_rule_ids
 from boa_restrictor.cli.utils import parse_source_code_or_fail
 from boa_restrictor.common.noqa import get_noqa_comments
 from boa_restrictor.rules import get_rules
@@ -31,6 +32,15 @@ def main(argv: Sequence[str] | None = None):
     globally_excluded_rules = configuration.get("exclude", [])
     enable_django_rules = configuration.get("enable_django_rules", True)
     per_file_excluded_rules: dict[str, list[str]] = configuration.get("per-file-excludes", {})
+    custom_rule_paths = configuration.get("custom_rules", [])
+
+    # Resolve all rules eagerly so import/validation errors fail fast before any file is processed
+    builtin_rules = get_rules(use_django_rules=enable_django_rules)
+    config_anchor_dir = (Path.cwd() / args.config).parent
+    custom_rules = load_custom_rules(paths=custom_rule_paths, anchor_dir=config_anchor_dir)
+    enabled_rules = builtin_rules + custom_rules
+    validate_unique_rule_ids(rules=enabled_rules)
+    active_rule_ids = {rule_class.RULE_ID for rule_class in enabled_rules}
 
     # Iterate over all filenames coming from pre-commit...
     occurrences = []
@@ -46,15 +56,21 @@ def main(argv: Sequence[str] | None = None):
         noqa_tokens = get_noqa_comments(source_code=source_code)
 
         # Iterate over all linters...
-        enabled_rules = get_rules(use_django_rules=enable_django_rules)
         for rule_class in enabled_rules:
             # Skip linters, which have been excluded globally via the configuration
-            if is_rule_excluded(rule_class=rule_class, excluded_rules=globally_excluded_rules):
+            if is_rule_excluded(
+                rule_class=rule_class,
+                excluded_rules=globally_excluded_rules,
+                active_rule_ids=active_rule_ids,
+            ):
                 continue
 
             # Iterate per-file rule exclusions
             if is_rule_excluded_per_file(
-                filename=filename, rule_class=rule_class, per_file_excluded_rules=per_file_excluded_rules
+                filename=filename,
+                rule_class=rule_class,
+                per_file_excluded_rules=per_file_excluded_rules,
+                active_rule_ids=active_rule_ids,
             ):
                 continue
 

--- a/boa_restrictor/cli/main.py
+++ b/boa_restrictor/cli/main.py
@@ -53,7 +53,7 @@ def main(argv: Sequence[str] | None = None):
         source_tree = parse_source_code_or_fail(filename=filename, source_code=source_code)
 
         # Fetch all ignored line comments
-        noqa_tokens = get_noqa_comments(source_code=source_code)
+        noqa_tokens = get_noqa_comments(source_code=source_code, filename=filename)
 
         # Iterate over all linters...
         for rule_class in enabled_rules:

--- a/boa_restrictor/common/noqa.py
+++ b/boa_restrictor/common/noqa.py
@@ -20,6 +20,10 @@ def get_noqa_comments(*, source_code: str) -> list[tuple[int, set[str]]]:
       - "# noqa: TST0011" does NOT suppress rule TST001 (substring guard).
       - "# noqa: PBR001 explanation here" yields just {"PBR001"} — prose tokens
         are ignored because they don't match the rule-code shape.
+
+    Only the payload after "# noqa:" (and before any subsequent "#") contributes
+    codes, so code-shaped tokens elsewhere in the comment do not silently widen
+    the suppression.
     """
     noqa_statements = []
 
@@ -28,9 +32,11 @@ def get_noqa_comments(*, source_code: str) -> list[tuple[int, set[str]]]:
         token_type, token_string, start, _, _ = token
         if token_type != tokenize.COMMENT:
             continue
-        if not _NOQA_PATTERN.search(token_string):
+        match = _NOQA_PATTERN.search(token_string)
+        if not match:
             continue
-        codes = set(_CODE_PATTERN.findall(token_string))
+        payload = token_string[match.end() :].split("#", 1)[0]
+        codes = set(_CODE_PATTERN.findall(payload))
         if codes:
             noqa_statements.append((start[0], codes))
 

--- a/boa_restrictor/common/noqa.py
+++ b/boa_restrictor/common/noqa.py
@@ -2,8 +2,10 @@ import re
 import tokenize
 from io import StringIO
 
-# Matches a noqa directive comment; requires at least one non-whitespace char after the colon.
-_NOQA_PATTERN = re.compile(r"^#\snoqa:\s*\S")
+# Matches a noqa directive anywhere within a comment token, so a noqa following another
+# inline pragma still registers. Case-insensitive (accepts uppercase NOQA) and tolerant
+# of missing whitespace around the leading hash and the colon.
+_NOQA_PATTERN = re.compile(r"#\s*noqa\s*:", re.IGNORECASE)
 # Rule code pattern: 1+ uppercase letters followed by 1+ digits (e.g. PBR001, DBR007, TST0011, F401).
 # Anything in the noqa payload that doesn't match this is ignored (prose, stray punctuation, ...).
 _CODE_PATTERN = re.compile(r"\b[A-Z]+\d+\b")
@@ -26,10 +28,9 @@ def get_noqa_comments(*, source_code: str) -> list[tuple[int, set[str]]]:
         token_type, token_string, start, _, _ = token
         if token_type != tokenize.COMMENT:
             continue
-        stripped = token_string.strip()
-        if not _NOQA_PATTERN.match(stripped):
+        if not _NOQA_PATTERN.search(token_string):
             continue
-        codes = set(_CODE_PATTERN.findall(stripped))
+        codes = set(_CODE_PATTERN.findall(token_string))
         if codes:
             noqa_statements.append((start[0], codes))
 

--- a/boa_restrictor/common/noqa.py
+++ b/boa_restrictor/common/noqa.py
@@ -2,6 +2,8 @@ import re
 import tokenize
 from io import StringIO
 
+from boa_restrictor.exceptions.syntax_errors import BoaRestrictorParsingError
+
 # Matches a noqa directive anywhere within a comment token, so a noqa following another
 # inline pragma still registers. Case-insensitive (accepts uppercase NOQA) and tolerant
 # of missing whitespace around the leading hash and the colon.
@@ -11,7 +13,7 @@ _NOQA_PATTERN = re.compile(r"#\s*noqa\s*:", re.IGNORECASE)
 _CODE_PATTERN = re.compile(r"\b[A-Z]+\d+\b")
 
 
-def get_noqa_comments(*, source_code: str) -> list[tuple[int, set[str]]]:
+def get_noqa_comments(*, source_code: str, filename: str = "<unknown>") -> list[tuple[int, set[str]]]:
     """
     Walk the target code and collect all "# noqa: <CODE[, ...]>" comments,
     returning each as (line_number, set_of_exact_rule_ids).
@@ -28,16 +30,19 @@ def get_noqa_comments(*, source_code: str) -> list[tuple[int, set[str]]]:
     noqa_statements = []
 
     tokens = tokenize.generate_tokens(StringIO(source_code).readline)
-    for token in tokens:
-        token_type, token_string, start, _, _ = token
-        if token_type != tokenize.COMMENT:
-            continue
-        match = _NOQA_PATTERN.search(token_string)
-        if not match:
-            continue
-        payload = token_string[match.end() :].split("#", 1)[0]
-        codes = set(_CODE_PATTERN.findall(payload))
-        if codes:
-            noqa_statements.append((start[0], codes))
+    try:
+        for token in tokens:
+            token_type, token_string, start, _, _ = token
+            if token_type != tokenize.COMMENT:
+                continue
+            match = _NOQA_PATTERN.search(token_string)
+            if not match:
+                continue
+            payload = token_string[match.end() :].split("#", 1)[0]
+            codes = set(_CODE_PATTERN.findall(payload))
+            if codes:
+                noqa_statements.append((start[0], codes))
+    except tokenize.TokenError as e:
+        raise BoaRestrictorParsingError(filename=filename) from e
 
     return noqa_statements

--- a/boa_restrictor/common/noqa.py
+++ b/boa_restrictor/common/noqa.py
@@ -2,22 +2,30 @@ import re
 import tokenize
 from io import StringIO
 
-# Matches any "# noqa: <CODE>" comment regardless of rule prefix. The per-rule filter
-# (rule_class.RULE_ID in comment_string) in main.py decides which comments apply to which rule,
-# so this pattern stays permissive to support custom (project-defined) rule IDs.
-_NOQA_PATTERN = re.compile(r"^#\snoqa:\s*\S")
+# Matches a noqa directive comment and captures the whole code list so we can split it.
+_NOQA_PATTERN = re.compile(r"^#\snoqa:\s*(\S.*)$")
+_CODE_SEPARATOR = re.compile(r"[,\s]+")
 
 
-def get_noqa_comments(*, source_code: str) -> list[tuple[int, str]]:
+def get_noqa_comments(*, source_code: str) -> list[tuple[int, set[str]]]:
     """
-    Walk the target code and detect all lines having a "# noqa: <CODE>" comment.
+    Walk the target code and collect all "# noqa: <CODE[, ...]>" comments,
+    returning each as (line_number, set_of_exact_rule_ids).
+    Rule IDs are matched exactly downstream, so a substring like "TST001" in
+    "# noqa: TST0011" will not falsely suppress a violation.
     """
     noqa_statements = []
 
     tokens = tokenize.generate_tokens(StringIO(source_code).readline)
     for token in tokens:
         token_type, token_string, start, _, _ = token
-        if token_type == tokenize.COMMENT and _NOQA_PATTERN.search(token_string):
-            noqa_statements.append((start[0], token_string.strip()))
+        if token_type != tokenize.COMMENT:
+            continue
+        match = _NOQA_PATTERN.match(token_string.strip())
+        if not match:
+            continue
+        codes = {part for part in _CODE_SEPARATOR.split(match.group(1)) if part}
+        if codes:
+            noqa_statements.append((start[0], codes))
 
     return noqa_statements

--- a/boa_restrictor/common/noqa.py
+++ b/boa_restrictor/common/noqa.py
@@ -2,26 +2,22 @@ import re
 import tokenize
 from io import StringIO
 
-from boa_restrictor.common.rule import DJANGO_LINTING_RULE_PREFIX, PYTHON_LINTING_RULE_PREFIX
+# Matches any "# noqa: <CODE>" comment regardless of rule prefix. The per-rule filter
+# (rule_class.RULE_ID in comment_string) in main.py decides which comments apply to which rule,
+# so this pattern stays permissive to support custom (project-defined) rule IDs.
+_NOQA_PATTERN = re.compile(r"^#\snoqa:\s*\S")
 
 
 def get_noqa_comments(*, source_code: str) -> list[tuple[int, str]]:
     """
-    Walk the target code and detect all lines having a "# noqa" comment with "our" prefix.
+    Walk the target code and detect all lines having a "# noqa: <CODE>" comment.
     """
     noqa_statements = []
 
     tokens = tokenize.generate_tokens(StringIO(source_code).readline)
-    patterns = [
-        re.compile(r"^#\snoqa:\s*.*?" + PYTHON_LINTING_RULE_PREFIX + r"\d{3}"),
-        re.compile(r"^#\snoqa:\s*.*?" + DJANGO_LINTING_RULE_PREFIX + r"\d{3}"),
-    ]
-
     for token in tokens:
         token_type, token_string, start, _, _ = token
-
-        for pattern in patterns:
-            if token_type == tokenize.COMMENT and pattern.search(token_string):
-                noqa_statements.append((start[0], token_string.strip()))
+        if token_type == tokenize.COMMENT and _NOQA_PATTERN.search(token_string):
+            noqa_statements.append((start[0], token_string.strip()))
 
     return noqa_statements

--- a/boa_restrictor/common/noqa.py
+++ b/boa_restrictor/common/noqa.py
@@ -2,17 +2,22 @@ import re
 import tokenize
 from io import StringIO
 
-# Matches a noqa directive comment and captures the whole code list so we can split it.
-_NOQA_PATTERN = re.compile(r"^#\snoqa:\s*(\S.*)$")
-_CODE_SEPARATOR = re.compile(r"[,\s]+")
+# Matches a noqa directive comment; requires at least one non-whitespace char after the colon.
+_NOQA_PATTERN = re.compile(r"^#\snoqa:\s*\S")
+# Rule code pattern: 1+ uppercase letters followed by 1+ digits (e.g. PBR001, DBR007, TST0011, F401).
+# Anything in the noqa payload that doesn't match this is ignored (prose, stray punctuation, ...).
+_CODE_PATTERN = re.compile(r"\b[A-Z]+\d+\b")
 
 
 def get_noqa_comments(*, source_code: str) -> list[tuple[int, set[str]]]:
     """
     Walk the target code and collect all "# noqa: <CODE[, ...]>" comments,
     returning each as (line_number, set_of_exact_rule_ids).
-    Rule IDs are matched exactly downstream, so a substring like "TST001" in
-    "# noqa: TST0011" will not falsely suppress a violation.
+
+    Rule IDs are matched exactly downstream, so:
+      - "# noqa: TST0011" does NOT suppress rule TST001 (substring guard).
+      - "# noqa: PBR001 explanation here" yields just {"PBR001"} — prose tokens
+        are ignored because they don't match the rule-code shape.
     """
     noqa_statements = []
 
@@ -21,10 +26,10 @@ def get_noqa_comments(*, source_code: str) -> list[tuple[int, set[str]]]:
         token_type, token_string, start, _, _ = token
         if token_type != tokenize.COMMENT:
             continue
-        match = _NOQA_PATTERN.match(token_string.strip())
-        if not match:
+        stripped = token_string.strip()
+        if not _NOQA_PATTERN.match(stripped):
             continue
-        codes = {part for part in _CODE_SEPARATOR.split(match.group(1)) if part}
+        codes = set(_CODE_PATTERN.findall(stripped))
         if codes:
             noqa_statements.append((start[0], codes))
 

--- a/boa_restrictor/common/rule.py
+++ b/boa_restrictor/common/rule.py
@@ -6,6 +6,10 @@ from boa_restrictor.projections.occurrence import Occurrence
 PYTHON_LINTING_RULE_PREFIX = "PBR"
 DJANGO_LINTING_RULE_PREFIX = "DBR"
 
+# RULE_ID prefixes reserved for built-in rules. Custom (project-defined) rules must use
+# a different prefix.
+RESERVED_RULE_ID_PREFIXES = (PYTHON_LINTING_RULE_PREFIX, DJANGO_LINTING_RULE_PREFIX)
+
 
 class Rule:
     RULE_ID: str

--- a/boa_restrictor/exceptions/custom_rules.py
+++ b/boa_restrictor/exceptions/custom_rules.py
@@ -8,7 +8,14 @@ class CustomRuleConfigurationError(CustomRuleError):
 
 class CustomRulesNotAListError(CustomRuleConfigurationError):
     def __init__(self):
-        super().__init__('Configuration value "custom_rules" must be a list of dotted import paths (strings).')
+        super().__init__('Configuration value "custom_rules" must be a list.')
+
+
+class CustomRulePathNotAStringError(CustomRuleConfigurationError):
+    def __init__(self, value):
+        super().__init__(
+            f"Each entry in custom_rules must be a string (dotted import path); got {type(value).__name__}: {value!r}."
+        )
 
 
 class DuplicateCustomRulePathError(CustomRuleConfigurationError):
@@ -73,10 +80,14 @@ class CustomRuleReservedPrefixError(CustomRuleValidationError):
         )
 
 
-class DuplicateRuleIdError(CustomRuleError):
-    def __init__(self, *, rule_id: str, first: type, second: type):
-        super().__init__(
-            f'Duplicate RULE_ID "{rule_id}" used by '
-            f'"{first.__module__}.{first.__qualname__}" and '
-            f'"{second.__module__}.{second.__qualname__}".'
-        )
+class DuplicateRuleIdError(CustomRuleValidationError):
+    def __init__(self, *, clashes: list[tuple[str, type, type]]):
+        """
+        `clashes` is a list of (rule_id, first_class, second_class) for every detected duplicate.
+        """
+        lines = [
+            f'  - "{rule_id}": "{first.__module__}.{first.__qualname__}" '
+            f'and "{second.__module__}.{second.__qualname__}"'
+            for rule_id, first, second in clashes
+        ]
+        super().__init__("Duplicate RULE_IDs detected:\n" + "\n".join(lines))

--- a/boa_restrictor/exceptions/custom_rules.py
+++ b/boa_restrictor/exceptions/custom_rules.py
@@ -75,6 +75,22 @@ class CustomRuleMissingRuleLabelError(CustomRuleValidationError):
         super().__init__(f'Custom rule "{dotted_path}" does not set RULE_LABEL.')
 
 
+class CustomRuleInvalidRuleIdTypeError(CustomRuleValidationError):
+    def __init__(self, *, dotted_path: str, value):
+        super().__init__(
+            f'Custom rule "{dotted_path}" has a non-string RULE_ID '
+            f"(got {type(value).__name__}: {value!r}). RULE_ID must be a string."
+        )
+
+
+class CustomRuleInvalidRuleLabelTypeError(CustomRuleValidationError):
+    def __init__(self, *, dotted_path: str, value):
+        super().__init__(
+            f'Custom rule "{dotted_path}" has a non-string RULE_LABEL '
+            f"(got {type(value).__name__}: {value!r}). RULE_LABEL must be a string."
+        )
+
+
 class CustomRuleReservedPrefixError(CustomRuleValidationError):
     def __init__(self, *, dotted_path: str, prefix: str, reserved_prefixes: tuple[str, ...]):
         super().__init__(

--- a/boa_restrictor/exceptions/custom_rules.py
+++ b/boa_restrictor/exceptions/custom_rules.py
@@ -36,11 +36,14 @@ class InvalidCustomRulePathError(CustomRuleImportError):
 
 class CustomRuleModuleImportFailedError(CustomRuleImportError):
     def __init__(self, *, module_path: str, dotted_path: str, original: BaseException):
-        super().__init__(
-            f'Could not import module "{module_path}" for custom rule "{dotted_path}": {original}. '
-            f"Make sure your project is on the Python path "
-            f"(see boa-restrictor docs on running with custom rules under pre-commit)."
-        )
+        if isinstance(original, SyntaxError):
+            hint = "Fix the syntax error in your rule module."
+        else:
+            hint = (
+                "Make sure your project is on the Python path "
+                "(see boa-restrictor docs on running with custom rules under pre-commit)."
+            )
+        super().__init__(f'Could not import module "{module_path}" for custom rule "{dotted_path}": {original}. {hint}')
 
 
 class CustomRuleAttributeMissingError(CustomRuleImportError):
@@ -81,13 +84,14 @@ class CustomRuleReservedPrefixError(CustomRuleValidationError):
 
 
 class DuplicateRuleIdError(CustomRuleValidationError):
-    def __init__(self, *, clashes: list[tuple[str, type, type]]):
+    def __init__(self, *, clashes: dict[str, list[type]]):
         """
-        `clashes` is a list of (rule_id, first_class, second_class) for every detected duplicate.
+        `clashes` maps each clashing RULE_ID to the list of classes sharing that ID.
+        Grouped by ID so triple-clashes show as one line listing all offenders rather than
+        N-1 pairwise lines.
         """
         lines = [
-            f'  - "{rule_id}": "{first.__module__}.{first.__qualname__}" '
-            f'and "{second.__module__}.{second.__qualname__}"'
-            for rule_id, first, second in clashes
+            f'  - "{rule_id}": ' + ", ".join(f'"{c.__module__}.{c.__qualname__}"' for c in classes)
+            for rule_id, classes in clashes.items()
         ]
         super().__init__("Duplicate RULE_IDs detected:\n" + "\n".join(lines))

--- a/boa_restrictor/exceptions/custom_rules.py
+++ b/boa_restrictor/exceptions/custom_rules.py
@@ -1,0 +1,82 @@
+class CustomRuleError(ValueError):
+    """Base error for custom-rule loading and validation failures."""
+
+
+class CustomRuleConfigurationError(CustomRuleError):
+    """Structural problem in the custom_rules config value."""
+
+
+class CustomRulesNotAListError(CustomRuleConfigurationError):
+    def __init__(self):
+        super().__init__('Configuration value "custom_rules" must be a list of dotted import paths (strings).')
+
+
+class DuplicateCustomRulePathError(CustomRuleConfigurationError):
+    def __init__(self, dotted_path: str):
+        super().__init__(f'Duplicate entry in custom_rules: "{dotted_path}".')
+
+
+class CustomRuleImportError(CustomRuleError):
+    """Failure importing a custom rule's module or attribute."""
+
+
+class InvalidCustomRulePathError(CustomRuleImportError):
+    def __init__(self, dotted_path: str):
+        super().__init__(
+            f'Invalid custom rule path "{dotted_path}". Expected a dotted path of the form "module.ClassName".'
+        )
+
+
+class CustomRuleModuleImportFailedError(CustomRuleImportError):
+    def __init__(self, *, module_path: str, dotted_path: str, original: BaseException):
+        super().__init__(
+            f'Could not import module "{module_path}" for custom rule "{dotted_path}": {original}. '
+            f"Make sure your project is on the Python path "
+            f"(see boa-restrictor docs on running with custom rules under pre-commit)."
+        )
+
+
+class CustomRuleAttributeMissingError(CustomRuleImportError):
+    def __init__(self, *, module_path: str, attr_name: str, dotted_path: str):
+        super().__init__(f'Module "{module_path}" has no attribute "{attr_name}" (custom rule "{dotted_path}").')
+
+
+class CustomRuleValidationError(CustomRuleError):
+    """A loaded object failed Rule contract validation."""
+
+
+class CustomRuleNotAClassError(CustomRuleValidationError):
+    def __init__(self, dotted_path: str):
+        super().__init__(f'Custom rule "{dotted_path}" is not a class.')
+
+
+class CustomRuleNotARuleSubclassError(CustomRuleValidationError):
+    def __init__(self, dotted_path: str):
+        super().__init__(f'Custom rule "{dotted_path}" must subclass boa_restrictor.common.rule.Rule.')
+
+
+class CustomRuleMissingRuleIdError(CustomRuleValidationError):
+    def __init__(self, dotted_path: str):
+        super().__init__(f'Custom rule "{dotted_path}" does not set RULE_ID.')
+
+
+class CustomRuleMissingRuleLabelError(CustomRuleValidationError):
+    def __init__(self, dotted_path: str):
+        super().__init__(f'Custom rule "{dotted_path}" does not set RULE_LABEL.')
+
+
+class CustomRuleReservedPrefixError(CustomRuleValidationError):
+    def __init__(self, *, dotted_path: str, prefix: str, reserved_prefixes: tuple[str, ...]):
+        super().__init__(
+            f'Custom rule "{dotted_path}" uses reserved RULE_ID prefix "{prefix}". '
+            f"Prefixes {reserved_prefixes} are reserved for built-in rules."
+        )
+
+
+class DuplicateRuleIdError(CustomRuleError):
+    def __init__(self, *, rule_id: str, first: type, second: type):
+        super().__init__(
+            f'Duplicate RULE_ID "{rule_id}" used by '
+            f'"{first.__module__}.{first.__qualname__}" and '
+            f'"{second.__module__}.{second.__qualname__}".'
+        )

--- a/boa_restrictor/exceptions/custom_rules.py
+++ b/boa_restrictor/exceptions/custom_rules.py
@@ -91,6 +91,15 @@ class CustomRuleInvalidRuleLabelTypeError(CustomRuleValidationError):
         )
 
 
+class CustomRuleInvalidRuleIdShapeError(CustomRuleValidationError):
+    def __init__(self, *, dotted_path: str, rule_id: str):
+        super().__init__(
+            f'Custom rule "{dotted_path}" has malformed RULE_ID "{rule_id}". '
+            "RULE_IDs must be one or more uppercase ASCII letters followed by one or more digits "
+            '(e.g. "TST001"). Lowercase or punctuated IDs cannot be silenced via "# noqa:".'
+        )
+
+
 class CustomRuleReservedPrefixError(CustomRuleValidationError):
     def __init__(self, *, dotted_path: str, prefix: str, reserved_prefixes: tuple[str, ...]):
         super().__init__(

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -59,6 +59,100 @@ You can disable rules on a per-file-basis in your `pyproject.toml` file as follo
 Take care that the path is relative to the location of your pyproject.toml. This means that example two targets all
 files living in a `scripts/` directory on the projects top level.
 
+## Project-specific (custom) rules
+
+You can register your own rule classes alongside the built-in ones by listing them in your `pyproject.toml`:
+
+```toml
+[tool.boa-restrictor]
+custom_rules = [
+    "myproject.linting.NoFooBarRule",
+    "myproject.linting.RequireBazRule",
+]
+```
+
+Each entry is a dotted import path to a class that subclasses
+`boa_restrictor.common.rule.Rule` and sets a `RULE_ID` and `RULE_LABEL`. A minimal example:
+
+```python
+import ast
+
+from boa_restrictor.common.rule import Rule
+from boa_restrictor.projections.occurrence import Occurrence
+
+
+class NoFooBarRule(Rule):
+    RULE_ID = "MYP001"
+    RULE_LABEL = 'Functions must not be named "foo_bar".'
+
+    def check(self) -> list[Occurrence]:
+        occurrences = []
+        for node in ast.walk(self.source_tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "foo_bar":
+                occurrences.append(
+                    Occurrence(
+                        rule_id=self.RULE_ID,
+                        rule_label=self.RULE_LABEL,
+                        filename=self.filename,
+                        file_path=self.file_path,
+                        identifier=node.name,
+                        line_number=node.lineno,
+                    )
+                )
+        return occurrences
+```
+
+Custom rules participate in the same exclusion mechanisms as the built-ins
+(`exclude`, `per-file-excludes`, and `# noqa: <rule_id>`).
+
+### Rule ID requirements
+
+* The `PBR` and `DBR` prefixes are reserved for built-in rules. Pick any other prefix.
+* Every loaded rule must have a unique `RULE_ID`. Duplicate IDs (within your custom rules,
+  or against a built-in) abort the run with an error naming both classes.
+* Validation is eager: a misconfigured `custom_rules` entry fails the run before any file is linted.
+* If a custom rule raises during `check()`, the linting run halts. Treat exceptions inside
+  `check()` as bugs in your rule.
+
+### Running custom rules under pre-commit
+
+Custom rules need your project's modules to be importable when boa-restrictor runs. The standard
+pre-commit hook installs boa-restrictor into an isolated virtualenv that does **not** see your
+project code, so you have two options:
+
+**Option A — `language: system` (simplest).** boa-restrictor runs in the environment you've installed
+it into (typically your project venv). You lose pre-commit's automatic version management — pin
+boa-restrictor in your dev requirements instead.
+
+```yaml
+  - repo: local
+    hooks:
+      - id: boa-restrictor
+        name: boa-restrictor
+        entry: boa-restrictor
+        language: system
+        types: [python]
+        args: [--config=pyproject.toml]
+```
+
+**Option B — `additional_dependencies` (preferable if your project is pip-installable).** Keeps
+pre-commit's hermetic environment and installs your package into the hook's venv.
+
+```yaml
+  - repo: https://github.com/ambient-innovation/boa-restrictor
+    rev: v{{ version }}
+    hooks:
+      - id: boa-restrictor
+        args: [--config=pyproject.toml]
+        additional_dependencies: [".", "boa-restrictor"]
+```
+
+### Common gotcha: Django imports at module top-level
+
+boa-restrictor does not bootstrap Django before importing your custom rule modules. If your rule
+needs anything from `django.conf` / `django.db` / etc., import it inside `check()`, not at module
+scope, or you will see `ImproperlyConfigured` errors during loading.
+
 ## Python version compatibility
 
 boa-restrictor uses Python's built-in `ast.parse()` to analyze your source code. This means the Python version

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -147,6 +147,13 @@ pre-commit's hermetic environment and installs your package into the hook's venv
         additional_dependencies: [".", "boa-restrictor"]
 ```
 
+### Trust model
+
+Listing a path under `custom_rules` causes boa-restrictor to **import and execute** the named
+module at lint time. Only point this at code you trust. If you run boa-restrictor against
+contributors' branches in CI (e.g. PRs from forks), assume that whoever can edit `pyproject.toml`
+can run arbitrary code in your CI environment.
+
 ### Common gotcha: Django imports at module top-level
 
 boa-restrictor does not bootstrap Django before importing your custom rule modules. If your rule

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -150,9 +150,10 @@ pre-commit's hermetic environment and installs your package into the hook's venv
 ### Trust model
 
 Listing a path under `custom_rules` causes boa-restrictor to **import and execute** the named
-module at lint time. Only point this at code you trust. If you run boa-restrictor against
-contributors' branches in CI (e.g. PRs from forks), assume that whoever can edit `pyproject.toml`
-can run arbitrary code in your CI environment.
+module at lint time. boa-restrictor does not sandbox imported rule modules. Only point this at
+code you trust. If you run boa-restrictor against contributors' branches in CI (e.g. PRs from
+forks), assume that whoever can edit `pyproject.toml` can run arbitrary code in your CI
+environment.
 
 ### Common gotcha: Django imports at module top-level
 

--- a/tests/cli/test_configuration.py
+++ b/tests/cli/test_configuration.py
@@ -71,6 +71,13 @@ def test_is_rule_excluded_invalid_rule(mocked_warn):
     mocked_warn.assert_called_once()
 
 
+@mock.patch.object(warnings, "warn")
+def test_is_rule_excluded_invalid_rule_does_not_disable_other_exclusions(mocked_warn):
+    """A typo in the exclusion list must warn but still honour the remaining valid IDs."""
+    assert is_rule_excluded(rule_class=AsteriskRequiredRule, excluded_rules=["TYPO123", "PBR001"]) is True
+    mocked_warn.assert_called_once()
+
+
 def test_is_rule_excluded_per_file_is_excluded():
     assert (
         is_rule_excluded_per_file(

--- a/tests/cli/test_configuration.py
+++ b/tests/cli/test_configuration.py
@@ -124,3 +124,38 @@ def test_is_rule_excluded_per_file_exclude_subdirectory():
         )
         is True
     )
+
+
+def test_is_rule_excluded_active_rule_ids_recognises_custom_rule():
+    """A rule ID in active_rule_ids must not trigger the Invalid rule warning."""
+    with mock.patch.object(warnings, "warn") as mocked_warn:
+        result = is_rule_excluded(
+            rule_class=AsteriskRequiredRule,
+            excluded_rules=["TST001"],
+            active_rule_ids={"PBR001", "TST001"},
+        )
+    mocked_warn.assert_not_called()
+    assert result is False
+
+
+def test_is_rule_excluded_active_rule_ids_warns_on_unknown_id():
+    with mock.patch.object(warnings, "warn") as mocked_warn:
+        is_rule_excluded(
+            rule_class=AsteriskRequiredRule,
+            excluded_rules=["UNK999"],
+            active_rule_ids={"PBR001", "TST001"},
+        )
+    mocked_warn.assert_called_once()
+
+
+def test_is_rule_excluded_per_file_passes_active_rule_ids_through():
+    """The per-file check must thread active_rule_ids into is_rule_excluded."""
+    with mock.patch.object(warnings, "warn") as mocked_warn:
+        result = is_rule_excluded_per_file(
+            filename="apps/file.py",
+            rule_class=AsteriskRequiredRule,
+            per_file_excluded_rules={"*.py": ["TST001"]},
+            active_rule_ids={"PBR001", "TST001"},
+        )
+    mocked_warn.assert_not_called()
+    assert result is False

--- a/tests/cli/test_custom_rules.py
+++ b/tests/cli/test_custom_rules.py
@@ -76,6 +76,26 @@ def test_load_custom_rules_anchor_not_duplicated(tmp_path):
     assert len(sys.path) == sys_path_len_before
 
 
+def test_load_custom_rules_anchor_canonicalised_for_dedup(tmp_path):
+    """Non-canonical anchors (containing '..') must dedup against the resolved form,
+    so repeated invocations don't accumulate duplicate sys.path entries."""
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    canonical = str(tmp_path.resolve())
+    sys.path.insert(0, canonical)
+    sys_path_len_before = len(sys.path)
+
+    # Pass a non-canonical form pointing at the same directory
+    non_canonical = sub / ".."
+    load_custom_rules(
+        paths=[f"{FIXTURE_MODULE}.SampleCustomRule"],
+        anchor_dir=non_canonical,
+    )
+
+    assert len(sys.path) == sys_path_len_before
+    assert canonical in sys.path
+
+
 def test_load_custom_rules_paths_must_be_list():
     with pytest.raises(CustomRuleConfigurationError, match=r"must be a list"):
         load_custom_rules(paths="myproject.MyRule", anchor_dir=Path.cwd())
@@ -197,6 +217,25 @@ def test_load_custom_rules_non_string_rule_label():
     with pytest.raises(CustomRuleValidationError, match=r"non-string RULE_LABEL"):
         load_custom_rules(
             paths=[f"{FIXTURE_MODULE}.RuleWithNonStringRuleLabel"],
+            anchor_dir=Path.cwd(),
+        )
+
+
+def test_load_custom_rules_lowercase_rule_id_rejected():
+    """Lowercase RULE_IDs cannot be silenced via # noqa: (the noqa parser accepts only
+    uppercase), so reject them at load time rather than letting them load and silently
+    misbehave."""
+    with pytest.raises(CustomRuleValidationError, match=r"malformed RULE_ID"):
+        load_custom_rules(
+            paths=[f"{FIXTURE_MODULE}.RuleWithLowercaseRuleId"],
+            anchor_dir=Path.cwd(),
+        )
+
+
+def test_load_custom_rules_punctuated_rule_id_rejected():
+    with pytest.raises(CustomRuleValidationError, match=r"malformed RULE_ID"):
+        load_custom_rules(
+            paths=[f"{FIXTURE_MODULE}.RuleWithPunctuatedRuleId"],
             anchor_dir=Path.cwd(),
         )
 

--- a/tests/cli/test_custom_rules.py
+++ b/tests/cli/test_custom_rules.py
@@ -183,6 +183,24 @@ def test_load_custom_rules_missing_rule_label():
         )
 
 
+def test_load_custom_rules_non_string_rule_id():
+    """A non-string RULE_ID must raise a clean validation error rather than an AttributeError
+    on the downstream str.startswith() check."""
+    with pytest.raises(CustomRuleValidationError, match=r"non-string RULE_ID"):
+        load_custom_rules(
+            paths=[f"{FIXTURE_MODULE}.RuleWithNonStringRuleId"],
+            anchor_dir=Path.cwd(),
+        )
+
+
+def test_load_custom_rules_non_string_rule_label():
+    with pytest.raises(CustomRuleValidationError, match=r"non-string RULE_LABEL"):
+        load_custom_rules(
+            paths=[f"{FIXTURE_MODULE}.RuleWithNonStringRuleLabel"],
+            anchor_dir=Path.cwd(),
+        )
+
+
 def test_load_custom_rules_reserved_python_prefix():
     with pytest.raises(CustomRuleValidationError, match=r'reserved RULE_ID prefix "PBR"'):
         load_custom_rules(

--- a/tests/cli/test_custom_rules.py
+++ b/tests/cli/test_custom_rules.py
@@ -76,13 +76,16 @@ def test_load_custom_rules_anchor_not_duplicated(tmp_path):
 
 
 def test_load_custom_rules_paths_must_be_list():
-    with pytest.raises(CustomRuleConfigurationError, match="must be a list"):
+    with pytest.raises(CustomRuleConfigurationError, match=r"must be a list"):
         load_custom_rules(paths="myproject.MyRule", anchor_dir=Path.cwd())
 
 
 def test_load_custom_rules_paths_must_contain_strings():
-    with pytest.raises(CustomRuleConfigurationError, match="must be a list"):
+    with pytest.raises(CustomRuleConfigurationError, match=r"must be a string") as exc_info:
         load_custom_rules(paths=[123], anchor_dir=Path.cwd())
+
+    # The offending value should be cited so users can find their typo
+    assert "123" in str(exc_info.value)
 
 
 def test_load_custom_rules_duplicate_path():
@@ -104,6 +107,21 @@ def test_load_custom_rules_bad_path_no_dot():
 def test_load_custom_rules_module_not_found():
     with pytest.raises(CustomRuleImportError, match=r"Could not import module"):
         load_custom_rules(paths=["nonexistent_pkg.SomeRule"], anchor_dir=Path.cwd())
+
+
+def test_load_custom_rules_module_raises_non_import_error():
+    """A custom rule module that raises e.g. RuntimeError (or Django's ImproperlyConfigured)
+    at import time should still be re-framed as a CustomRuleImportError so users get an
+    actionable message instead of a raw traceback."""
+    with pytest.raises(CustomRuleImportError, match=r"Could not import module") as exc_info:
+        load_custom_rules(
+            paths=["tests.fixtures.raises_at_import.Anything"],
+            anchor_dir=Path.cwd(),
+        )
+
+    # The original RuntimeError should chain via __cause__
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert "simulated module-import-time failure" in str(exc_info.value.__cause__)
 
 
 def test_load_custom_rules_attr_not_found():
@@ -184,3 +202,25 @@ def test_validate_unique_rule_ids_duplicate_against_builtin():
     assert "PBR001" in message
     assert "AsteriskRequiredRule" in message
     assert "RuleCollidingWithBuiltin" in message
+
+
+def test_validate_unique_rule_ids_reports_all_clashes_at_once():
+    """A single error should list every duplicate so users do not have to fix-and-rerun repeatedly."""
+    with pytest.raises(DuplicateRuleIdError) as exc_info:
+        validate_unique_rule_ids(
+            rules=(
+                AsteriskRequiredRule,  # PBR001
+                SampleCustomRule,  # TST001
+                RuleCollidingWithBuiltin,  # PBR001 clash
+                RuleClashingWithSample,  # TST001 clash
+            )
+        )
+
+    message = str(exc_info.value)
+    # Both clashes must appear in the same error message
+    assert "PBR001" in message
+    assert "TST001" in message
+    assert "AsteriskRequiredRule" in message
+    assert "SampleCustomRule" in message
+    assert "RuleCollidingWithBuiltin" in message
+    assert "RuleClashingWithSample" in message

--- a/tests/cli/test_custom_rules.py
+++ b/tests/cli/test_custom_rules.py
@@ -240,6 +240,33 @@ def test_load_custom_rules_punctuated_rule_id_rejected():
         )
 
 
+def test_load_custom_rules_letters_only_rule_id_rejected():
+    """RULE_ID without any digits violates ^[A-Z]+\\d+$ and must be rejected."""
+    with pytest.raises(CustomRuleValidationError, match=r"malformed RULE_ID"):
+        load_custom_rules(
+            paths=[f"{FIXTURE_MODULE}.RuleWithLettersOnlyRuleId"],
+            anchor_dir=Path.cwd(),
+        )
+
+
+def test_load_custom_rules_digits_only_rule_id_rejected():
+    """RULE_ID without any letters violates ^[A-Z]+\\d+$ and must be rejected."""
+    with pytest.raises(CustomRuleValidationError, match=r"malformed RULE_ID"):
+        load_custom_rules(
+            paths=[f"{FIXTURE_MODULE}.RuleWithDigitsOnlyRuleId"],
+            anchor_dir=Path.cwd(),
+        )
+
+
+def test_load_custom_rules_trailing_letters_rule_id_rejected():
+    """A letter after the digit run violates ^[A-Z]+\\d+$ and must be rejected."""
+    with pytest.raises(CustomRuleValidationError, match=r"malformed RULE_ID"):
+        load_custom_rules(
+            paths=[f"{FIXTURE_MODULE}.RuleWithTrailingLettersRuleId"],
+            anchor_dir=Path.cwd(),
+        )
+
+
 def test_load_custom_rules_reserved_python_prefix():
     with pytest.raises(CustomRuleValidationError, match=r'reserved RULE_ID prefix "PBR"'):
         load_custom_rules(

--- a/tests/cli/test_custom_rules.py
+++ b/tests/cli/test_custom_rules.py
@@ -16,6 +16,7 @@ from tests.fixtures.custom_rule_module import (
     RuleClashingWithSample,
     RuleCollidingWithBuiltin,
     SampleCustomRule,
+    ThirdRuleClashingWithSample,
 )
 
 FIXTURE_MODULE = "tests.fixtures.custom_rule_module"
@@ -124,6 +125,24 @@ def test_load_custom_rules_module_raises_non_import_error():
     assert "simulated module-import-time failure" in str(exc_info.value.__cause__)
 
 
+def test_load_custom_rules_syntax_error_message_is_specific(tmp_path):
+    """A SyntaxError in the user's rule module should produce a syntax-specific hint
+    rather than the generic "Make sure your project is on the Python path" message."""
+    broken_module = tmp_path / "broken_rule.py"
+    broken_module.write_text("def thing(:\n    pass\n")  # invalid syntax
+
+    with pytest.raises(CustomRuleImportError) as exc_info:
+        load_custom_rules(
+            paths=["broken_rule.SomeRule"],
+            anchor_dir=tmp_path,
+        )
+
+    message = str(exc_info.value)
+    assert "Fix the syntax error" in message
+    assert "Python path" not in message
+    assert isinstance(exc_info.value.__cause__, SyntaxError)
+
+
 def test_load_custom_rules_attr_not_found():
     with pytest.raises(CustomRuleImportError, match=r"has no attribute"):
         load_custom_rules(
@@ -224,3 +243,21 @@ def test_validate_unique_rule_ids_reports_all_clashes_at_once():
     assert "SampleCustomRule" in message
     assert "RuleCollidingWithBuiltin" in message
     assert "RuleClashingWithSample" in message
+
+
+def test_validate_unique_rule_ids_groups_triple_clash_on_one_line():
+    """A triple-clash should report all three offenders under one rule-ID heading,
+    not as three pairwise comparisons."""
+    with pytest.raises(DuplicateRuleIdError) as exc_info:
+        validate_unique_rule_ids(
+            rules=(SampleCustomRule, RuleClashingWithSample, ThirdRuleClashingWithSample),
+        )
+
+    message = str(exc_info.value)
+    # Exactly one line per clashing RULE_ID
+    clash_lines = [line for line in message.splitlines() if line.strip().startswith("-")]
+    assert len(clash_lines) == 1
+    # All three offenders named on that single line
+    assert "SampleCustomRule" in clash_lines[0]
+    assert "RuleClashingWithSample" in clash_lines[0]
+    assert "ThirdRuleClashingWithSample" in clash_lines[0]

--- a/tests/cli/test_custom_rules.py
+++ b/tests/cli/test_custom_rules.py
@@ -1,0 +1,186 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+from boa_restrictor.cli.custom_rules import load_custom_rules, validate_unique_rule_ids
+from boa_restrictor.exceptions.custom_rules import (
+    CustomRuleConfigurationError,
+    CustomRuleImportError,
+    CustomRuleValidationError,
+    DuplicateRuleIdError,
+)
+from boa_restrictor.rules import AsteriskRequiredRule
+from tests.fixtures.custom_rule_module import (
+    AnotherCustomRule,
+    RuleClashingWithSample,
+    RuleCollidingWithBuiltin,
+    SampleCustomRule,
+)
+
+FIXTURE_MODULE = "tests.fixtures.custom_rule_module"
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_path():
+    original = list(sys.path)
+    yield
+    sys.path[:] = original
+
+
+def test_load_custom_rules_empty_list():
+    assert load_custom_rules(paths=[], anchor_dir=Path.cwd()) == ()
+
+
+def test_load_custom_rules_happy_path():
+    rules = load_custom_rules(
+        paths=[f"{FIXTURE_MODULE}.SampleCustomRule"],
+        anchor_dir=Path.cwd(),
+    )
+    assert rules == (SampleCustomRule,)
+
+
+def test_load_custom_rules_multiple_in_order():
+    rules = load_custom_rules(
+        paths=[
+            f"{FIXTURE_MODULE}.SampleCustomRule",
+            f"{FIXTURE_MODULE}.AnotherCustomRule",
+        ],
+        anchor_dir=Path.cwd(),
+    )
+    assert rules == (SampleCustomRule, AnotherCustomRule)
+
+
+def test_load_custom_rules_injects_anchor_into_sys_path(tmp_path):
+    load_custom_rules(paths=[], anchor_dir=tmp_path)
+    # Empty paths should not pollute sys.path
+    assert str(tmp_path) not in sys.path
+
+
+def test_load_custom_rules_anchor_inserted_when_paths_present(tmp_path):
+    load_custom_rules(
+        paths=[f"{FIXTURE_MODULE}.SampleCustomRule"],
+        anchor_dir=tmp_path,
+    )
+    assert sys.path[0] == str(tmp_path)
+
+
+def test_load_custom_rules_anchor_not_duplicated(tmp_path):
+    sys.path.insert(0, str(tmp_path))
+    sys_path_len_before = len(sys.path)
+    load_custom_rules(
+        paths=[f"{FIXTURE_MODULE}.SampleCustomRule"],
+        anchor_dir=tmp_path,
+    )
+    assert len(sys.path) == sys_path_len_before
+
+
+def test_load_custom_rules_paths_must_be_list():
+    with pytest.raises(CustomRuleConfigurationError, match="must be a list"):
+        load_custom_rules(paths="myproject.MyRule", anchor_dir=Path.cwd())
+
+
+def test_load_custom_rules_paths_must_contain_strings():
+    with pytest.raises(CustomRuleConfigurationError, match="must be a list"):
+        load_custom_rules(paths=[123], anchor_dir=Path.cwd())
+
+
+def test_load_custom_rules_duplicate_path():
+    with pytest.raises(CustomRuleConfigurationError, match=r"Duplicate entry"):
+        load_custom_rules(
+            paths=[
+                f"{FIXTURE_MODULE}.SampleCustomRule",
+                f"{FIXTURE_MODULE}.SampleCustomRule",
+            ],
+            anchor_dir=Path.cwd(),
+        )
+
+
+def test_load_custom_rules_bad_path_no_dot():
+    with pytest.raises(CustomRuleImportError, match=r'Expected a dotted path of the form "module.ClassName"'):
+        load_custom_rules(paths=["just_a_name"], anchor_dir=Path.cwd())
+
+
+def test_load_custom_rules_module_not_found():
+    with pytest.raises(CustomRuleImportError, match=r"Could not import module"):
+        load_custom_rules(paths=["nonexistent_pkg.SomeRule"], anchor_dir=Path.cwd())
+
+
+def test_load_custom_rules_attr_not_found():
+    with pytest.raises(CustomRuleImportError, match=r"has no attribute"):
+        load_custom_rules(
+            paths=[f"{FIXTURE_MODULE}.DoesNotExist"],
+            anchor_dir=Path.cwd(),
+        )
+
+
+def test_load_custom_rules_not_a_class():
+    with pytest.raises(CustomRuleValidationError, match=r"is not a class"):
+        load_custom_rules(
+            paths=[f"{FIXTURE_MODULE}.not_a_class"],
+            anchor_dir=Path.cwd(),
+        )
+
+
+def test_load_custom_rules_not_a_rule_subclass():
+    with pytest.raises(CustomRuleValidationError, match=r"must subclass"):
+        load_custom_rules(
+            paths=[f"{FIXTURE_MODULE}.NotARuleSubclass"],
+            anchor_dir=Path.cwd(),
+        )
+
+
+def test_load_custom_rules_missing_rule_id():
+    with pytest.raises(CustomRuleValidationError, match=r"does not set RULE_ID"):
+        load_custom_rules(
+            paths=[f"{FIXTURE_MODULE}.RuleWithoutRuleId"],
+            anchor_dir=Path.cwd(),
+        )
+
+
+def test_load_custom_rules_missing_rule_label():
+    with pytest.raises(CustomRuleValidationError, match=r"does not set RULE_LABEL"):
+        load_custom_rules(
+            paths=[f"{FIXTURE_MODULE}.RuleWithoutRuleLabel"],
+            anchor_dir=Path.cwd(),
+        )
+
+
+def test_load_custom_rules_reserved_python_prefix():
+    with pytest.raises(CustomRuleValidationError, match=r'reserved RULE_ID prefix "PBR"'):
+        load_custom_rules(
+            paths=[f"{FIXTURE_MODULE}.RuleWithReservedPrefix"],
+            anchor_dir=Path.cwd(),
+        )
+
+
+def test_load_custom_rules_reserved_django_prefix():
+    with pytest.raises(CustomRuleValidationError, match=r'reserved RULE_ID prefix "DBR"'):
+        load_custom_rules(
+            paths=[f"{FIXTURE_MODULE}.RuleWithReservedDjangoPrefix"],
+            anchor_dir=Path.cwd(),
+        )
+
+
+def test_validate_unique_rule_ids_happy_path():
+    validate_unique_rule_ids(rules=(SampleCustomRule, AnotherCustomRule))
+
+
+def test_validate_unique_rule_ids_duplicate_within_customs():
+    with pytest.raises(DuplicateRuleIdError) as exc_info:
+        validate_unique_rule_ids(rules=(SampleCustomRule, RuleClashingWithSample))
+
+    message = str(exc_info.value)
+    assert "TST001" in message
+    assert "SampleCustomRule" in message
+    assert "RuleClashingWithSample" in message
+
+
+def test_validate_unique_rule_ids_duplicate_against_builtin():
+    with pytest.raises(DuplicateRuleIdError) as exc_info:
+        validate_unique_rule_ids(rules=(AsteriskRequiredRule, RuleCollidingWithBuiltin))
+
+    message = str(exc_info.value)
+    assert "PBR001" in message
+    assert "AsteriskRequiredRule" in message
+    assert "RuleCollidingWithBuiltin" in message

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -9,6 +9,7 @@ import pytest
 
 from boa_restrictor.cli.main import main
 from boa_restrictor.common.rule import Rule
+from boa_restrictor.exceptions.custom_rules import DuplicateRuleIdError
 from boa_restrictor.projections.occurrence import Occurrence
 from boa_restrictor.rules import BOA_RESTRICTOR_RULES, DJANGO_BOA_RULES, AsteriskRequiredRule
 from tests.fixtures.custom_rule_module import SampleCustomRule
@@ -345,6 +346,53 @@ def test_main_custom_rule_noqa_uses_exact_match_not_substring(*args):
 
     # The TST0011 noqa is unrelated; TST001 must still surface.
     assert "TST001" in mock_stdout.getvalue()
+
+
+@mock.patch(
+    "boa_restrictor.cli.main.load_configuration",
+    return_value={
+        "custom_rules": [
+            CUSTOM_RULE_PATH,
+            "tests.fixtures.custom_rule_module.RuleClashingWithSample",
+        ],
+    },
+)
+def test_main_aborts_on_duplicate_rule_ids_before_reading_files(*args):
+    """A RULE_ID clash among loaded rules must abort main() before any file is opened."""
+    with mock.patch("builtins.open") as mocked_open:
+        with pytest.raises(DuplicateRuleIdError):
+            main(
+                argv=(
+                    "thing.py",
+                    "--config",
+                    "pyproject.toml",
+                )
+            )
+
+    # The mocked file open must never have been called — validation aborts first.
+    mocked_open.assert_not_called()
+
+
+@mock.patch(
+    "boa_restrictor.cli.main.load_configuration",
+    return_value={"custom_rules": [CUSTOM_RULE_PATH]},
+)
+@mock.patch("builtins.open", mock.mock_open(read_data="x = 1\n"))
+def test_main_propagates_exception_raised_in_custom_rule_check(*args):
+    """Documented contract: an exception inside check() halts the run (no per-file swallow)."""
+
+    class CustomRuleBoomError(RuntimeError):
+        pass
+
+    with mock.patch.object(SampleCustomRule, "run_check", side_effect=CustomRuleBoomError("kaboom")):
+        with pytest.raises(CustomRuleBoomError, match="kaboom"):
+            main(
+                argv=(
+                    "thing.py",
+                    "--config",
+                    "pyproject.toml",
+                )
+            )
 
 
 @mock.patch(

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -11,6 +11,7 @@ from boa_restrictor.cli.main import main
 from boa_restrictor.common.rule import Rule
 from boa_restrictor.projections.occurrence import Occurrence
 from boa_restrictor.rules import BOA_RESTRICTOR_RULES, DJANGO_BOA_RULES, AsteriskRequiredRule
+from tests.fixtures.custom_rule_module import SampleCustomRule
 
 
 @mock.patch.object(argparse.ArgumentParser, "parse_args")
@@ -224,3 +225,91 @@ def test_main_per_file_exclusion_skips_rule(mocked_run_check, mocked_is_excluded
     mocked_is_excluded.assert_called()
     # Verify that the rule check was NOT called for the excluded rule
     mocked_run_check.assert_not_called()
+
+
+CUSTOM_RULE_PATH = "tests.fixtures.custom_rule_module.SampleCustomRule"
+
+
+@mock.patch(
+    "boa_restrictor.cli.main.load_configuration",
+    return_value={"custom_rules": [CUSTOM_RULE_PATH]},
+)
+@mock.patch("builtins.open", mock.mock_open(read_data="# test file"))
+def test_main_custom_rule_is_executed(*args):
+    with mock.patch.object(SampleCustomRule, "run_check", return_value=[]) as mocked_check:
+        main(
+            argv=(
+                os.path.abspath(sys.argv[0]),
+                "--config",
+                "pyproject.toml",
+            )
+        )
+
+    mocked_check.assert_called_once()
+
+
+@mock.patch(
+    "boa_restrictor.cli.main.load_configuration",
+    return_value={"custom_rules": [CUSTOM_RULE_PATH], "exclude": ["TST001"]},
+)
+@mock.patch("builtins.open", mock.mock_open(read_data="# test file"))
+def test_main_custom_rule_can_be_excluded_globally(*args):
+    with mock.patch.object(SampleCustomRule, "run_check") as mocked_check:
+        main(
+            argv=(
+                os.path.abspath(sys.argv[0]),
+                "--config",
+                "pyproject.toml",
+            )
+        )
+
+    mocked_check.assert_not_called()
+
+
+@mock.patch(
+    "boa_restrictor.cli.main.load_configuration",
+    return_value={
+        "custom_rules": [CUSTOM_RULE_PATH],
+        "per-file-excludes": {"*.py": ["TST001"]},
+    },
+)
+@mock.patch("builtins.open", mock.mock_open(read_data="# test file"))
+def test_main_custom_rule_can_be_excluded_per_file(*args):
+    with mock.patch.object(SampleCustomRule, "run_check") as mocked_check:
+        main(
+            argv=(
+                "test_file.py",
+                "--config",
+                "pyproject.toml",
+            )
+        )
+
+    mocked_check.assert_not_called()
+
+
+@mock.patch(
+    "boa_restrictor.cli.main.load_configuration",
+    return_value={"custom_rules": [CUSTOM_RULE_PATH]},
+)
+@mock.patch("builtins.open", mock.mock_open(read_data="def thing():\n    pass  # noqa: TST001\n"))
+def test_main_custom_rule_honors_noqa_on_line(*args):
+    fake_occurrence = Occurrence(
+        rule_id="TST001",
+        rule_label="Sample custom rule for tests.",
+        filename="thing.py",
+        file_path=Path("thing.py"),
+        identifier="thing",
+        line_number=2,
+    )
+    with mock.patch.object(SampleCustomRule, "run_check", return_value=[fake_occurrence]):
+        with mock.patch("sys.stdout", new=StringIO()) as mock_stdout:
+            main(
+                argv=(
+                    "thing.py",
+                    "--config",
+                    "pyproject.toml",
+                )
+            )
+
+    # The noqa: TST001 on line 2 should suppress the occurrence
+    assert "TST001" not in mock_stdout.getvalue()

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -313,3 +313,66 @@ def test_main_custom_rule_honors_noqa_on_line(*args):
 
     # The noqa: TST001 on line 2 should suppress the occurrence
     assert "TST001" not in mock_stdout.getvalue()
+
+
+@mock.patch(
+    "boa_restrictor.cli.main.load_configuration",
+    return_value={"custom_rules": [CUSTOM_RULE_PATH]},
+)
+@mock.patch(
+    "builtins.open",
+    mock.mock_open(read_data="def thing():\n    pass  # noqa: TST0011\n"),
+)
+def test_main_custom_rule_noqa_uses_exact_match_not_substring(*args):
+    """Regression: # noqa: TST0011 must NOT suppress rule TST001 (substring false positive)."""
+    fake_occurrence = Occurrence(
+        rule_id="TST001",
+        rule_label="Sample custom rule for tests.",
+        filename="thing.py",
+        file_path=Path("thing.py"),
+        identifier="thing",
+        line_number=2,
+    )
+    with mock.patch.object(SampleCustomRule, "run_check", return_value=[fake_occurrence]):
+        with mock.patch("sys.stdout", new=StringIO()) as mock_stdout:
+            main(
+                argv=(
+                    "thing.py",
+                    "--config",
+                    "pyproject.toml",
+                )
+            )
+
+    # The TST0011 noqa is unrelated; TST001 must still surface.
+    assert "TST001" in mock_stdout.getvalue()
+
+
+@mock.patch(
+    "boa_restrictor.cli.main.load_configuration",
+    return_value={"custom_rules": [CUSTOM_RULE_PATH]},
+)
+@mock.patch("builtins.open", mock.mock_open(read_data="x = 1\n"))
+def test_main_custom_rule_violation_appears_in_stdout(*args):
+    """End-to-end: a custom rule's Occurrence reaches the CLI output."""
+    fake_occurrence = Occurrence(
+        rule_id="TST001",
+        rule_label="Sample custom rule for tests.",
+        filename="thing.py",
+        file_path=Path("thing.py"),
+        identifier="thing",
+        line_number=1,
+    )
+    with mock.patch.object(SampleCustomRule, "run_check", return_value=[fake_occurrence]):
+        with mock.patch("sys.stdout", new=StringIO()) as mock_stdout:
+            result = main(
+                argv=(
+                    "thing.py",
+                    "--config",
+                    "pyproject.toml",
+                )
+            )
+
+    output = mock_stdout.getvalue()
+    assert "TST001" in output
+    assert "Sample custom rule for tests." in output
+    assert result is True

--- a/tests/common/test_noqa.py
+++ b/tests/common/test_noqa.py
@@ -150,3 +150,33 @@ def test_get_noqa_comments_codes_outside_directive_are_ignored():
     result = get_noqa_comments(source_code=source_code)
 
     assert len(result) == 0
+
+
+def test_get_noqa_comments_codes_before_directive_are_ignored():
+    """Code-shaped tokens in prose BEFORE the noqa directive must not be silenced."""
+    source_code = """x = 7  # fixes PBR001 ticket  # noqa: PBR002"""
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 1
+    assert result[0] == (1, {"PBR002"})
+
+
+def test_get_noqa_comments_codes_in_leftover_note_are_ignored():
+    """Code-shaped tokens in a trailing note after a second '#' must not be silenced."""
+    source_code = """x = 7  # noqa: PBR001  # also see PBR777"""
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 1
+    assert result[0] == (1, {"PBR001"})
+
+
+def test_get_noqa_comments_codes_in_other_pragma_are_ignored():
+    """Code-shaped tokens inside another inline pragma before noqa must not be silenced."""
+    source_code = """x = 7  # type: ignore[PBR999]  # noqa: PBR002"""
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 1
+    assert result[0] == (1, {"PBR002"})

--- a/tests/common/test_noqa.py
+++ b/tests/common/test_noqa.py
@@ -7,9 +7,7 @@ def test_get_noqa_comments_has_pbr_noqa():
     result = get_noqa_comments(source_code=source_code)
 
     assert len(result) == 1
-    assert isinstance(result[0], tuple)
-    assert result[0][0] == 1
-    assert result[0][1] == "# noqa: PBR001"
+    assert result[0] == (1, {"PBR001"})
 
 
 def test_get_noqa_comments_has_dbr_noqa():
@@ -18,9 +16,7 @@ def test_get_noqa_comments_has_dbr_noqa():
     result = get_noqa_comments(source_code=source_code)
 
     assert len(result) == 1
-    assert isinstance(result[0], tuple)
-    assert result[0][0] == 1
-    assert result[0][1] == "# noqa: DBR002"
+    assert result[0] == (1, {"DBR002"})
 
 
 def test_get_noqa_comments_no_noqa_comment():
@@ -38,12 +34,50 @@ def test_get_noqa_comments_has_custom_rule_noqa():
     result = get_noqa_comments(source_code=source_code)
 
     assert len(result) == 1
-    assert result[0] == (1, "# noqa: TST001")
+    assert result[0] == (1, {"TST001"})
 
 
 def test_get_noqa_comments_ignores_bare_noqa_keyword():
     """A # noqa with no code following should not be collected (we do not support a global noqa)."""
     source_code = """x = 7  # noqa"""
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 0
+
+
+def test_get_noqa_comments_parses_multiple_codes_comma_separated():
+    source_code = """x = 7  # noqa: PBR001, F401"""
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 1
+    assert result[0] == (1, {"PBR001", "F401"})
+
+
+def test_get_noqa_comments_parses_multiple_codes_space_separated():
+    source_code = """x = 7  # noqa: PBR001 F401"""
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 1
+    assert result[0] == (1, {"PBR001", "F401"})
+
+
+def test_get_noqa_comments_codes_are_exact_not_substrings():
+    """Regression: # noqa: TST0011 must NOT be parsed as also containing TST001."""
+    source_code = """x = 7  # noqa: TST0011"""
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 1
+    assert result[0] == (1, {"TST0011"})
+    assert "TST001" not in result[0][1]
+
+
+def test_get_noqa_comments_separator_only_input_yields_no_codes():
+    """A noqa with only commas/whitespace after the colon should not register as a directive."""
+    source_code = """x = 7  # noqa: ,,,"""
 
     result = get_noqa_comments(source_code=source_code)
 

--- a/tests/common/test_noqa.py
+++ b/tests/common/test_noqa.py
@@ -111,3 +111,42 @@ def test_get_noqa_comments_ignores_inline_second_hash():
 
     assert len(result) == 1
     assert result[0] == (1, {"PBR001"})
+
+
+def test_get_noqa_comments_directive_after_another_pragma():
+    """Combined inline pragmas like `# type: ignore # noqa: PBR001` must still register."""
+    source_code = """x = 7  # type: ignore  # noqa: PBR001"""
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 1
+    assert result[0] == (1, {"PBR001"})
+
+
+def test_get_noqa_comments_uppercase_noqa_directive():
+    """Ruff/flake8 accept '# NOQA:' (uppercase). We should too."""
+    source_code = """x = 7  # NOQA: PBR001"""
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 1
+    assert result[0] == (1, {"PBR001"})
+
+
+def test_get_noqa_comments_no_space_around_directive():
+    """Tolerate '#noqa:' without a space and no space before the colon."""
+    source_code = """x = 7  #noqa:PBR001"""
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 1
+    assert result[0] == (1, {"PBR001"})
+
+
+def test_get_noqa_comments_codes_outside_directive_are_ignored():
+    """A code-shaped token in a comment without a noqa directive must NOT be treated as a code."""
+    source_code = """x = 7  # see ticket PBR001 for details"""
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 0

--- a/tests/common/test_noqa.py
+++ b/tests/common/test_noqa.py
@@ -29,3 +29,22 @@ def test_get_noqa_comments_no_noqa_comment():
     result = get_noqa_comments(source_code=source_code)
 
     assert len(result) == 0
+
+
+def test_get_noqa_comments_has_custom_rule_noqa():
+    """Custom (project-defined) rule IDs should be picked up too."""
+    source_code = """x = 7  # noqa: TST001"""
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 1
+    assert result[0] == (1, "# noqa: TST001")
+
+
+def test_get_noqa_comments_ignores_bare_noqa_keyword():
+    """A # noqa with no code following should not be collected (we do not support a global noqa)."""
+    source_code = """x = 7  # noqa"""
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 0

--- a/tests/common/test_noqa.py
+++ b/tests/common/test_noqa.py
@@ -1,4 +1,7 @@
+import pytest
+
 from boa_restrictor.common.noqa import get_noqa_comments
+from boa_restrictor.exceptions.syntax_errors import BoaRestrictorParsingError
 
 
 def test_get_noqa_comments_has_pbr_noqa():
@@ -180,3 +183,14 @@ def test_get_noqa_comments_codes_in_other_pragma_are_ignored():
 
     assert len(result) == 1
     assert result[0] == (1, {"PBR002"})
+
+
+def test_get_noqa_comments_tokenize_error_is_reframed():
+    """A TokenizeError (e.g. unterminated triple-quoted string) must surface as the
+    user-friendly BoaRestrictorParsingError, not a raw tokenize crash."""
+    source_code = 'x = """unterminated\n'
+
+    with pytest.raises(BoaRestrictorParsingError) as exc_info:
+        get_noqa_comments(source_code=source_code, filename="broken.py")
+
+    assert "broken.py" in str(exc_info.value)

--- a/tests/common/test_noqa.py
+++ b/tests/common/test_noqa.py
@@ -76,9 +76,38 @@ def test_get_noqa_comments_codes_are_exact_not_substrings():
 
 
 def test_get_noqa_comments_separator_only_input_yields_no_codes():
-    """A noqa with only commas/whitespace after the colon should not register as a directive."""
+    """A noqa with only commas after the colon should not register as a directive."""
     source_code = """x = 7  # noqa: ,,,"""
 
     result = get_noqa_comments(source_code=source_code)
 
     assert len(result) == 0
+
+
+def test_get_noqa_comments_whitespace_only_after_colon_yields_no_codes():
+    """A noqa with only whitespace after the colon must not match (no codes to silence)."""
+    source_code = "x = 7  # noqa:    "
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 0
+
+
+def test_get_noqa_comments_ignores_prose_tokens_after_codes():
+    """Prose tokens in the noqa payload (not matching the rule-code shape) must be ignored."""
+    source_code = """x = 7  # noqa: PBR001 explanation here"""
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 1
+    assert result[0] == (1, {"PBR001"})
+
+
+def test_get_noqa_comments_ignores_inline_second_hash():
+    """A second '#' (e.g. trailing comment) must not become a phantom code."""
+    source_code = """x = 7  # noqa: PBR001 # leftover note"""
+
+    result = get_noqa_comments(source_code=source_code)
+
+    assert len(result) == 1
+    assert result[0] == (1, {"PBR001"})

--- a/tests/exceptions/test_custom_rules.py
+++ b/tests/exceptions/test_custom_rules.py
@@ -1,0 +1,31 @@
+import pytest
+
+from boa_restrictor.exceptions.custom_rules import (
+    CustomRuleConfigurationError,
+    CustomRuleError,
+    CustomRuleImportError,
+    CustomRuleValidationError,
+    DuplicateRuleIdError,
+)
+
+
+@pytest.mark.parametrize(
+    "exc_cls",
+    [
+        CustomRuleConfigurationError,
+        CustomRuleImportError,
+        CustomRuleValidationError,
+        DuplicateRuleIdError,
+    ],
+)
+def test_custom_rule_errors_inherit_from_base(exc_cls):
+    assert issubclass(exc_cls, CustomRuleError)
+
+
+def test_custom_rule_error_inherits_from_value_error():
+    assert issubclass(CustomRuleError, ValueError)
+
+
+def test_custom_rule_error_carries_message():
+    with pytest.raises(CustomRuleError, match="boom"):
+        raise CustomRuleError("boom")

--- a/tests/fixtures/custom_rule_module.py
+++ b/tests/fixtures/custom_rule_module.py
@@ -77,4 +77,20 @@ class NotARuleSubclass:
     RULE_LABEL = "Not a Rule subclass."
 
 
+class RuleWithNonStringRuleId(Rule):
+    RULE_ID = 123
+    RULE_LABEL = "RULE_ID is not a string."
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
+class RuleWithNonStringRuleLabel(Rule):
+    RULE_ID = "TST900"
+    RULE_LABEL = 42
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
 not_a_class = "I am a string, not a class."

--- a/tests/fixtures/custom_rule_module.py
+++ b/tests/fixtures/custom_rule_module.py
@@ -64,6 +64,14 @@ class RuleClashingWithSample(Rule):
         return []
 
 
+class ThirdRuleClashingWithSample(Rule):
+    RULE_ID = "TST001"
+    RULE_LABEL = "Third rule clashing on TST001."
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
 class NotARuleSubclass:
     RULE_ID = "TST998"
     RULE_LABEL = "Not a Rule subclass."

--- a/tests/fixtures/custom_rule_module.py
+++ b/tests/fixtures/custom_rule_module.py
@@ -109,4 +109,28 @@ class RuleWithPunctuatedRuleId(Rule):
         return []
 
 
+class RuleWithLettersOnlyRuleId(Rule):
+    RULE_ID = "TST"
+    RULE_LABEL = "Letters-only RULE_ID — missing required digits."
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
+class RuleWithDigitsOnlyRuleId(Rule):
+    RULE_ID = "001"
+    RULE_LABEL = "Digits-only RULE_ID — missing required letters."
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
+class RuleWithTrailingLettersRuleId(Rule):
+    RULE_ID = "TST001A"
+    RULE_LABEL = "Trailing letters after digits — not allowed."
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
 not_a_class = "I am a string, not a class."

--- a/tests/fixtures/custom_rule_module.py
+++ b/tests/fixtures/custom_rule_module.py
@@ -1,0 +1,72 @@
+from boa_restrictor.common.rule import Rule
+from boa_restrictor.projections.occurrence import Occurrence
+
+
+class SampleCustomRule(Rule):
+    RULE_ID = "TST001"
+    RULE_LABEL = "Sample custom rule for tests."
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
+class AnotherCustomRule(Rule):
+    RULE_ID = "TST002"
+    RULE_LABEL = "Another sample rule."
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
+class RuleWithoutRuleId(Rule):
+    RULE_LABEL = "Forgot the RULE_ID."
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
+class RuleWithoutRuleLabel(Rule):
+    RULE_ID = "TST003"
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
+class RuleWithReservedPrefix(Rule):
+    RULE_ID = "PBR999"
+    RULE_LABEL = "Pretends to be a built-in."
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
+class RuleWithReservedDjangoPrefix(Rule):
+    RULE_ID = "DBR999"
+    RULE_LABEL = "Pretends to be a built-in Django rule."
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
+class RuleCollidingWithBuiltin(Rule):
+    RULE_ID = "PBR001"
+    RULE_LABEL = "Collides with a real built-in ID."
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
+class RuleClashingWithSample(Rule):
+    RULE_ID = "TST001"
+    RULE_LABEL = "Collides with SampleCustomRule."
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
+class NotARuleSubclass:
+    RULE_ID = "TST998"
+    RULE_LABEL = "Not a Rule subclass."
+
+
+not_a_class = "I am a string, not a class."

--- a/tests/fixtures/custom_rule_module.py
+++ b/tests/fixtures/custom_rule_module.py
@@ -93,4 +93,20 @@ class RuleWithNonStringRuleLabel(Rule):
         return []
 
 
+class RuleWithLowercaseRuleId(Rule):
+    RULE_ID = "tst001"
+    RULE_LABEL = "Lowercase RULE_ID — would never be silenceable via # noqa:."
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
+class RuleWithPunctuatedRuleId(Rule):
+    RULE_ID = "MY-001"
+    RULE_LABEL = "Hyphenated RULE_ID — not allowed."
+
+    def check(self) -> list[Occurrence]:
+        return []
+
+
 not_a_class = "I am a string, not a class."

--- a/tests/fixtures/raises_at_import.py
+++ b/tests/fixtures/raises_at_import.py
@@ -1,0 +1,7 @@
+"""Fixture module that raises a non-ImportError at import time.
+
+Used to verify the custom-rules loader frames generic module-load failures
+instead of letting them propagate raw (e.g. Django's ImproperlyConfigured).
+"""
+
+raise RuntimeError("simulated module-import-time failure")  # noqa: TRY003


### PR DESCRIPTION
Projects can now register their own Rule subclasses alongside the built-ins via custom_rules in pyproject.toml. Rules are loaded eagerly with strict validation: dotted paths must resolve to a Rule subclass with RULE_ID and RULE_LABEL set, the PBR/DBR prefixes are reserved, and IDs must be globally unique. The noqa parser was generalised so # noqa: <CODE> works for custom rule IDs, not just PBR/DBR.