### PR TITLE
Refine PBR009 and PBR010 (v1.15.1)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+**1.15.1** (2026-06-29)
+* `PBR010` now recognises `self.fail()` / `pytest.fail()` as assertions; documented the helper-delegation
+  limitation
+* `PBR009` no longer flags imports guarded by `if TYPE_CHECKING:`; they are never executed at runtime and impose
+  no runtime dependency
+
 **1.15.0** (2026-06-29)
 * Added rule `DBR008` requiring an explicit `related_name` on `ForeignKey`/`OneToOneField`/`ManyToManyField`
   (models that set `Meta.default_related_name` are exempt)

--- a/boa_restrictor/__init__.py
+++ b/boa_restrictor/__init__.py
@@ -1,3 +1,3 @@
 """A custom Python and Django linter from Ambient"""
 
-__version__ = "1.15.0"
+__version__ = "1.15.1"

--- a/boa_restrictor/rules/python/mandatory_test_assertion.py
+++ b/boa_restrictor/rules/python/mandatory_test_assertion.py
@@ -7,11 +7,18 @@ from boa_restrictor.projections.occurrence import Occurrence
 # Calls to "pytest.<name>(...)" that act as assertions (typically used as context managers).
 PYTEST_ASSERTION_HELPERS = frozenset({"raises", "warns", "deprecated_call"})
 
+# Calls that unconditionally fail the test (unittest's self.fail, pytest.fail). A test whose only
+# "check" is one of these inside an except-branch still asserts behaviour: it fails on the wrong path.
+FAILURE_CALL_NAMES = frozenset({"fail"})
+
 
 class MandatoryTestAssertionRule(Rule):
     """
     Ensures that every test function contains at least one assertion. A test that asserts nothing can never
     fail and therefore provides no protection against regressions.
+
+    A call to ``self.fail()`` / ``pytest.fail()`` counts as an assertion: such a test can fail (e.g. on the
+    wrong branch of a try/except) and therefore does protect against regressions.
     """
 
     RULE_ID = f"{PYTHON_LINTING_RULE_PREFIX}010"
@@ -51,9 +58,10 @@ class MandatoryTestAssertionRule(Rule):
         if isinstance(node, ast.Call):
             func = node.func
             if isinstance(func, ast.Attribute):
-                # Any assert-prefixed method call (e.g. self.assertEqual), or a pytest assertion helper
-                # used as a context manager (e.g. pytest.raises, see PYTEST_ASSERTION_HELPERS).
-                if func.attr.startswith("assert"):
+                # Any assert-prefixed method call (e.g. self.assertEqual), a failure call (e.g. self.fail,
+                # pytest.fail), or a pytest assertion helper used as a context manager (e.g. pytest.raises,
+                # see PYTEST_ASSERTION_HELPERS).
+                if func.attr.startswith("assert") or func.attr in FAILURE_CALL_NAMES:
                     return True
                 if (
                     isinstance(func.value, ast.Name)
@@ -61,9 +69,12 @@ class MandatoryTestAssertionRule(Rule):
                     and func.attr in PYTEST_ASSERTION_HELPERS
                 ):
                     return True
-            # Directly imported assert-prefixed helper (e.g. assertQuerySetEqual) or pytest assertion helper
-            # (e.g. "raises" imported via "from pytest import raises").
-            elif isinstance(func, ast.Name) and (func.id.startswith("assert") or func.id in PYTEST_ASSERTION_HELPERS):
+            # Directly imported assert-prefixed helper (e.g. assertQuerySetEqual), failure call (e.g. "fail"
+            # imported via "from pytest import fail") or pytest assertion helper (e.g. "raises" imported via
+            # "from pytest import raises").
+            elif isinstance(func, ast.Name) and (
+                func.id.startswith("assert") or func.id in PYTEST_ASSERTION_HELPERS or func.id in FAILURE_CALL_NAMES
+            ):
                 return True
 
         return False

--- a/boa_restrictor/rules/python/no_inline_imports_in_tests.py
+++ b/boa_restrictor/rules/python/no_inline_imports_in_tests.py
@@ -28,6 +28,24 @@ class NoInlineImportInTestsRule(Rule):
         inside_function = in_function or isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
 
         for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.If) and self._is_type_checking_guard(child):
+                # Imports guarded by ``if TYPE_CHECKING:`` are never executed at runtime and exist solely for
+                # annotations, so they impose no runtime dependency. Skip the guard's body, but keep checking the
+                # ``else`` branch, which does run at runtime.
+                for orelse_node in child.orelse:
+                    if inside_function and isinstance(orelse_node, (ast.Import, ast.ImportFrom)):
+                        occurrences.append(self._build_occurrence(line_number=orelse_node.lineno))
+                    self._collect(orelse_node, in_function=inside_function, occurrences=occurrences)
+                continue
             if inside_function and isinstance(child, (ast.Import, ast.ImportFrom)):
                 occurrences.append(self._build_occurrence(line_number=child.lineno))
             self._collect(child, in_function=inside_function, occurrences=occurrences)
+
+    @staticmethod
+    def _is_type_checking_guard(node: ast.If) -> bool:
+        test = node.test
+        if isinstance(test, ast.Name):
+            return test.id == "TYPE_CHECKING"
+        if isinstance(test, ast.Attribute):
+            return test.attr == "TYPE_CHECKING"
+        return False

--- a/docs/features/rules/python/009_no_inline_imports_in_tests.md
+++ b/docs/features/rules/python/009_no_inline_imports_in_tests.md
@@ -24,3 +24,14 @@ from myapp.services import MyService
 def test_something():
     assert MyService().process() is True
 ```
+
+Imports guarded by `if TYPE_CHECKING:` are exempt. They are never executed at runtime and exist solely for
+annotations, so they impose no runtime dependency:
+
+```python
+def test_something():
+    if TYPE_CHECKING:
+        from myapp.services import MyService
+
+    ...
+```

--- a/docs/features/rules/python/010_mandatory_test_assertion.md
+++ b/docs/features/rules/python/010_mandatory_test_assertion.md
@@ -8,10 +8,18 @@ The following are recognised as assertions:
 
 - a bare `assert ...` statement,
 - any call to an `assert*` method or function (e.g. `self.assertEqual(...)`, `self.assertRaises(...)`),
-- `pytest.raises(...)`, `pytest.warns(...)` and `pytest.deprecated_call(...)`.
+- `pytest.raises(...)`, `pytest.warns(...)` and `pytest.deprecated_call(...)`,
+- a call to `fail` (e.g. `self.fail(...)`, `pytest.fail(...)`): such a test can still fail — for example
+  on the wrong branch of a `try`/`except` — and therefore does protect against regressions.
 
 If you assert through a custom helper that the rule cannot recognise statically, silence the individual
 finding with `# noqa: PBR010`.
+
+## Known limitation
+
+The rule analyses one function at a time and does not follow calls. If a test delegates its assertions to
+a called helper method (e.g. `self._assert_state()`), the rule cannot see them and will flag the test.
+Either inline the assertion or suppress the finding with `# noqa: PBR010`.
 
 *Wrong:*
 

--- a/tests/rules/python/test_mandatory_test_assertion.py
+++ b/tests/rules/python/test_mandatory_test_assertion.py
@@ -87,6 +87,77 @@ def test_directly_imported_pytest_raises_is_ok():
     assert occurrences == []
 
 
+def test_self_fail_is_ok():
+    source_tree = ast.parse("""class MyTestCase(TestCase):
+    def test_something(self):
+        self.fail("should not get here")""")
+
+    occurrences = MandatoryTestAssertionRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == []
+
+
+def test_self_fail_in_except_branch_is_ok():
+    source_tree = ast.parse("""class MyTestCase(TestCase):
+    def test_something(self):
+        try:
+            do_something()
+        except ValueError:
+            self.fail("should not raise")""")
+
+    occurrences = MandatoryTestAssertionRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == []
+
+
+def test_pytest_fail_is_ok():
+    source_tree = ast.parse("""def test_something():
+    pytest.fail("should not get here")""")
+
+    occurrences = MandatoryTestAssertionRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == []
+
+
+def test_directly_imported_fail_is_ok():
+    source_tree = ast.parse("""def test_something():
+    fail("should not get here")""")
+
+    occurrences = MandatoryTestAssertionRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == []
+
+
+def test_cls_fail_is_ok():
+    source_tree = ast.parse("""class MyTestCase(TestCase):
+    @classmethod
+    def test_something(cls):
+        cls.fail("should not get here")""")
+
+    occurrences = MandatoryTestAssertionRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == []
+
+
+def test_plain_call_without_assert_or_fail_is_detected():
+    source_tree = ast.parse("""def test_something():
+    service.process()""")
+
+    occurrences = MandatoryTestAssertionRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == [_occurrence(line_number=1, identifier="test_something")]
+
+
+def test_typoed_assert_method_is_detected():
+    source_tree = ast.parse("""class MyTestCase(TestCase):
+    def test_something(self):
+        self.asser_called_once_with(1)""")
+
+    occurrences = MandatoryTestAssertionRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == [_occurrence(line_number=2, identifier="test_something")]
+
+
 def test_assertion_only_in_nested_helper_is_detected():
     source_tree = ast.parse("""def test_something():
     def _unused():

--- a/tests/rules/python/test_no_inline_imports_in_tests.py
+++ b/tests/rules/python/test_no_inline_imports_in_tests.py
@@ -132,6 +132,29 @@ def test_import_in_else_branch_of_type_checking_guard_is_detected():
     assert occurrences == [_occurrence(line_number=5)]
 
 
+def test_import_in_else_branch_at_module_level_is_ok():
+    source_tree = ast.parse("""if TYPE_CHECKING:
+    from os import path
+else:
+    import os
+""")
+
+    occurrences = NoInlineImportInTestsRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == []
+
+
+def test_inline_import_in_compound_guard_is_detected():
+    source_tree = ast.parse("""def test_something():
+    if a == b:
+        import os
+    assert os""")
+
+    occurrences = NoInlineImportInTestsRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == [_occurrence(line_number=3)]
+
+
 def test_inline_import_in_non_type_checking_guard_is_detected():
     source_tree = ast.parse("""def test_something():
     if some_condition:

--- a/tests/rules/python/test_no_inline_imports_in_tests.py
+++ b/tests/rules/python/test_no_inline_imports_in_tests.py
@@ -84,6 +84,65 @@ def test_inline_import_in_non_test_file_is_ok():
     assert occurrences == []
 
 
+def test_inline_type_checking_import_in_function_is_ok():
+    source_tree = ast.parse("""def test_something():
+    if TYPE_CHECKING:
+        from os import path
+    assert path""")
+
+    occurrences = NoInlineImportInTestsRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == []
+
+
+def test_inline_qualified_type_checking_import_in_function_is_ok():
+    source_tree = ast.parse("""def test_something():
+    if typing.TYPE_CHECKING:
+        from os import path
+    assert path""")
+
+    occurrences = NoInlineImportInTestsRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == []
+
+
+def test_module_level_type_checking_import_is_ok():
+    source_tree = ast.parse("""if TYPE_CHECKING:
+    from os import path
+
+
+def test_something():
+    assert path""")
+
+    occurrences = NoInlineImportInTestsRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == []
+
+
+def test_import_in_else_branch_of_type_checking_guard_is_detected():
+    source_tree = ast.parse("""def test_something():
+    if TYPE_CHECKING:
+        from os import path
+    else:
+        import os
+    assert os and path""")
+
+    occurrences = NoInlineImportInTestsRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == [_occurrence(line_number=5)]
+
+
+def test_inline_import_in_non_type_checking_guard_is_detected():
+    source_tree = ast.parse("""def test_something():
+    if some_condition:
+        import os
+    assert os""")
+
+    occurrences = NoInlineImportInTestsRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == [_occurrence(line_number=3)]
+
+
 def test_multiple_inline_imports_are_detected():
     source_tree = ast.parse("""def test_something():
     import os


### PR DESCRIPTION
* PBR010 now recognises `self.fail()` / `pytest.fail()` as assertions; documented the helper-delegation limitation
* PBR009 no longer flags imports guarded by `if TYPE_CHECKING:`; they are never executed at runtime and impose no runtime dependency