### PR TITLE
#78: Fix PBR010/PBR008 false positive on pytest fixtures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**1.16.2** (2026-07-16)
+  * Fixed `PBR010` and `PBR008` incorrectly flagging `@pytest.fixture` functions named `test_*` as tests (#78)
+
 **1.16.1** (2026-07-03)
   * Updated company and maintainer information to "Beyonder Deutschland"
 

--- a/boa_restrictor/__init__.py
+++ b/boa_restrictor/__init__.py
@@ -1,3 +1,3 @@
 """A custom Python and Django linter from Beyonder Deutschland"""
 
-__version__ = "1.16.1"
+__version__ = "1.16.2"

--- a/boa_restrictor/common/ast_utils.py
+++ b/boa_restrictor/common/ast_utils.py
@@ -1,4 +1,5 @@
 import ast
+from typing import TypeGuard
 
 
 def node_name(node) -> str | None:
@@ -10,6 +11,35 @@ def node_name(node) -> str | None:
     if isinstance(node, ast.Attribute):
         return node.attr
     return None
+
+
+def is_test_function(node) -> TypeGuard[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """
+    Returns whether the given AST node is a test function: a (sync or async) function whose name starts with
+    "test" and which is NOT a pytest fixture. pytest does not collect fixtures as tests even when they are
+    named "test_*" (e.g. a "test_client" fixture), so they must not be treated as tests.
+    """
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return False
+    if not node.name.startswith("test"):
+        return False
+    return not is_fixture(node)
+
+
+def is_fixture(node) -> bool:
+    """
+    Returns whether the given AST node is a function decorated as a pytest fixture, i.e. carrying a
+    "@pytest.fixture", "@pytest.fixture(...)" or (directly-imported) "@fixture" / "@fixture(...)" decorator.
+    """
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return False
+    for decorator in node.decorator_list:
+        # Unwrap parametrized decorators ("@pytest.fixture(...)" / "@fixture(...)") to their callee, so both
+        # "@pytest.fixture" and "@pytest.fixture(scope="module")" (and the directly-imported "@fixture") match.
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if node_name(target) == "fixture":
+            return True
+    return False
 
 
 def is_type_checking_if(node) -> bool:

--- a/boa_restrictor/rules/python/mandatory_test_assertion.py
+++ b/boa_restrictor/rules/python/mandatory_test_assertion.py
@@ -1,5 +1,6 @@
 import ast
 
+from boa_restrictor.common.ast_utils import is_test_function
 from boa_restrictor.common.file_detection import is_test_file
 from boa_restrictor.common.rule import PYTHON_LINTING_RULE_PREFIX, Rule
 from boa_restrictor.projections.occurrence import Occurrence
@@ -31,7 +32,7 @@ class MandatoryTestAssertionRule(Rule):
             return occurrences
 
         for node in ast.walk(self.source_tree):
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test"):
+            if is_test_function(node):
                 if not self._contains_assertion(node):
                     occurrences.append(self._build_occurrence(line_number=node.lineno, identifier=node.name))
 

--- a/boa_restrictor/rules/python/no_loops_in_tests.py
+++ b/boa_restrictor/rules/python/no_loops_in_tests.py
@@ -1,5 +1,6 @@
 import ast
 
+from boa_restrictor.common.ast_utils import is_test_function
 from boa_restrictor.common.file_detection import is_test_file
 from boa_restrictor.common.rule import PYTHON_LINTING_RULE_PREFIX, Rule
 from boa_restrictor.projections.occurrence import Occurrence
@@ -20,7 +21,7 @@ class NoLoopsInTestsRule(Rule):
             return occurrences
 
         for node in ast.walk(self.source_tree):
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test"):
+            if is_test_function(node):
                 if self._contains_loop_or_comprehension(node):
                     occurrences.append(self._build_occurrence(line_number=node.lineno, identifier=node.name))
 

--- a/docs/features/rules/python/010_mandatory_test_assertion.md
+++ b/docs/features/rules/python/010_mandatory_test_assertion.md
@@ -15,6 +15,10 @@ The following are recognised as assertions:
 If you assert through a custom helper that the rule cannot recognise statically, silence the individual
 finding with `# noqa: PBR010`.
 
+Functions decorated with `@pytest.fixture` (including parametrized forms such as
+`@pytest.fixture(scope="module")` and the directly-imported `@fixture`) are not treated as tests, even when
+their name starts with `test`, so they are never required to contain an assertion.
+
 ## Known limitation
 
 The rule analyses one function at a time and does not follow calls. If a test delegates its assertions to

--- a/tests/common/test_ast_utils.py
+++ b/tests/common/test_ast_utils.py
@@ -1,0 +1,87 @@
+import ast
+
+from boa_restrictor.common.ast_utils import is_fixture, is_test_function
+
+
+def _function_node(source: str):
+    return ast.parse(source).body[0]
+
+
+def test_plain_test_function_is_test_function():
+    node = _function_node("""def test_something():
+    pass""")
+
+    assert is_test_function(node) is True
+
+
+def test_async_test_function_is_test_function():
+    node = _function_node("""async def test_something():
+    pass""")
+
+    assert is_test_function(node) is True
+
+
+def test_non_test_function_is_not_test_function():
+    node = _function_node("""def helper():
+    pass""")
+
+    assert is_test_function(node) is False
+
+
+def test_pytest_fixture_is_not_test_function():
+    node = _function_node("""@pytest.fixture
+def test_client():
+    return Client()""")
+
+    assert is_test_function(node) is False
+
+
+def test_parametrized_pytest_fixture_is_not_test_function():
+    node = _function_node("""@pytest.fixture(scope="module")
+def test_client():
+    return Client()""")
+
+    assert is_test_function(node) is False
+
+
+def test_directly_imported_fixture_is_not_test_function():
+    node = _function_node("""@fixture
+def test_data():
+    return {}""")
+
+    assert is_test_function(node) is False
+
+
+def test_non_fixture_decorator_stays_test_function():
+    node = _function_node("""@pytest.mark.django_db
+def test_something():
+    pass""")
+
+    assert is_test_function(node) is True
+
+
+def test_non_function_node_is_not_test_function():
+    node = ast.parse("x = 1").body[0]
+
+    assert is_test_function(node) is False
+
+
+def test_pytest_fixture_is_fixture():
+    node = _function_node("""@pytest.fixture
+def some_fixture():
+    return object()""")
+
+    assert is_fixture(node) is True
+
+
+def test_undecorated_function_is_not_fixture():
+    node = _function_node("""def some_function():
+    return object()""")
+
+    assert is_fixture(node) is False
+
+
+def test_non_function_node_is_not_fixture():
+    node = ast.parse("x = 1").body[0]
+
+    assert is_fixture(node) is False

--- a/tests/rules/python/test_mandatory_test_assertion.py
+++ b/tests/rules/python/test_mandatory_test_assertion.py
@@ -207,6 +207,46 @@ def test_non_test_function_is_ignored():
     assert occurrences == []
 
 
+def test_pytest_fixture_without_assertion_is_ignored():
+    source_tree = ast.parse("""@pytest.fixture
+def test_client():
+    return Client()""")
+
+    occurrences = MandatoryTestAssertionRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == []
+
+
+def test_parametrized_pytest_fixture_without_assertion_is_ignored():
+    source_tree = ast.parse("""@pytest.fixture(scope="module")
+def test_client():
+    return Client()""")
+
+    occurrences = MandatoryTestAssertionRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == []
+
+
+def test_directly_imported_fixture_without_assertion_is_ignored():
+    source_tree = ast.parse("""@fixture
+def test_data():
+    return {}""")
+
+    occurrences = MandatoryTestAssertionRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == []
+
+
+def test_async_pytest_fixture_without_assertion_is_ignored():
+    source_tree = ast.parse("""@pytest.fixture
+async def test_thing():
+    return object()""")
+
+    occurrences = MandatoryTestAssertionRule.run_check(file_path=TEST_FILE_PATH, source_tree=source_tree)
+
+    assert occurrences == []
+
+
 def test_missing_assertion_in_non_test_file_is_ok():
     source_tree = ast.parse("""def test_something():
     do_something()""")

--- a/tests/rules/python/test_no_loops_in_tests.py
+++ b/tests/rules/python/test_no_loops_in_tests.py
@@ -197,6 +197,17 @@ def test_unittest_loop_is_detected_from_non_test_case_class():
     )
 
 
+def test_loops_ok_in_pytest_fixture():
+    source_tree = ast.parse("""@pytest.fixture
+def test_client():
+    for i in list:
+        pass""")
+
+    occurrences = NoLoopsInTestsRule.run_check(file_path=Path("/path/to/tests/test_file.py"), source_tree=source_tree)
+
+    assert len(occurrences) == 0
+
+
 def test_loops_ok_in_non_test_dir():
     source_tree = ast.parse("""def test_something():
     while i < 0:


### PR DESCRIPTION
PBR010 and PBR008 treated any function named test_* as a test, so a @pytest.fixture named like a test (e.g. test_client) was wrongly flagged. Extract a shared is_test_function() helper that excludes fixtures and use it in both rules.

## Description

Please include a summary of the change and which issue is fixed (if any).

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [ ] My code follows the style guidelines of this project (linting passes)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation where necessary
- [ ] I have added an entry to `CHANGES.md`
- [ ] I have bumped the version in `boa_restrictor/__init__.py`
